### PR TITLE
Fix up security group crawler and healthcheck ready for redundant prism

### DIFF
--- a/app/collectors/collector.scala
+++ b/app/collectors/collector.scala
@@ -9,6 +9,7 @@ import org.joda.time.DateTime
 import akka.actor.ActorSystem
 import play.api.Play.current
 import scala.concurrent.ExecutionContext
+import play.api.libs.json.Json.JsValueWrapper
 
 class CollectorAgent[T<:IndexedItem](val collectors:Seq[Collector[T]], lazyStartup:Boolean = true) extends Logging with LifecycleWithoutApp {
 
@@ -102,6 +103,7 @@ object CollectorAgent {
         val vendor = "prism"
         val account = "prism"
         val resources = Set("sources")
+        val jsonFields = Map.empty[String, JsValueWrapper]
       },
       oldestDate
     )

--- a/app/collectors/package.scala
+++ b/app/collectors/package.scala
@@ -1,0 +1,9 @@
+package collectors
+
+object `package` {
+  implicit class seq2wrap[T](seq: Seq[T]) {
+    def wrap: Option[Seq[T]] = {
+      if (seq.isEmpty) None else Some(seq)
+    }
+  }
+}

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -110,6 +110,7 @@ object ApiResult extends Logging {
           val account = "unknown"
           val vendor = "unknown"
           val resources = Set.empty[String]
+          val jsonFields = Map.empty[String, JsValueWrapper]
         },
         source.lastUpdated
       )
@@ -165,19 +166,17 @@ object Api extends Controller with Logging {
       if (notInitialisedSources.isEmpty) Map.empty else Map(sources.label -> notInitialisedSources)
     } { notInitialisedSources =>
       if (notInitialisedSources.isEmpty)
-        Json.obj("sources" -> "initialised")
+        Json.obj("healthcheck" -> "initialised")
       else
-        throw new ApiCallException(Json.obj("sources" -> "not yet initialised"))
+        throw new ApiCallException(Json.obj("healthcheck" -> "not yet initialised", "sources" -> notInitialisedSources.values.headOption), SERVICE_UNAVAILABLE)
     }
   }
 
-  def itemJson[T<:IndexedItem](item: T, expand: Boolean = false, filter: Matchable[JsValue] = ResourceFilter.all)(implicit request: RequestHeader, writes: Writes[T]): Option[JsValue] = {
+  def itemJson[T<:IndexedItem](item: T, expand: Boolean = false, label: Option[Label] = None, filter: Matchable[JsValue] = ResourceFilter.all)(implicit request: RequestHeader, writes: Writes[T]): Option[JsValue] = {
     val json = Json.toJson(item).as[JsObject]
     if (filter.isMatch(json)) {
       val filtered = if (expand) json else JsObject(json.fields.filter(List("id") contains _._1))
-      Some(filtered ++ Json.obj("meta"-> Json.obj(
-        "href" -> item.call.absoluteURL()
-      )))
+      Some(filtered ++ Json.obj("meta"-> Json.obj("href" -> item.call.absoluteURL(), "origin" -> label.map(_.origin))))
     } else {
       None
     }
@@ -213,9 +212,9 @@ object Api extends Controller with Logging {
           datum.data.find(_.id == id).map(datum.label -> Seq(_))
         }.toMap
       } { sources =>
-        val item = sources.values.flatten.headOption
-        item.map { i =>
-          itemJson(i, expand = true).get
+        sources.headOption.map {
+          case (label, items) =>
+            itemJson(items.head, expand = true, label=Some(label)).get
         } getOrElse {
           throw ApiCallException(Json.obj("id" -> s"Item with id $id doesn't exist"), NOT_FOUND)
         } 
@@ -228,7 +227,7 @@ object Api extends Controller with Logging {
       ApiResult.mr {
         val expand = request.getQueryString("_expand").isDefined
         val filter = ResourceFilter.fromRequestWithDefaults(defaultFilter:_*)
-        agent.get().map { agent => agent.label -> agent.data.flatMap(host => itemJson(host, expand, filter)) }.toMap
+        agent.get().map { agent => agent.label -> agent.data.flatMap(host => itemJson(host, expand, Some(agent.label), filter=filter)) }.toMap
       } { collection =>
         Json.obj(
           objectKey -> toJson(collection.values.flatten)

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -15,6 +15,10 @@ object joda {
 object model {
   import joda.dateTimeWrites
 
+  implicit val originWriter = new Writes[Origin] {
+    def writes(o: Origin): JsValue = o.toJson
+  }
+
   implicit val instanceSpecificationWriter = Json.writes[InstanceSpecification]
   implicit val managementEndpointWriter = Json.writes[ManagementEndpoint]
   implicit val instanceWriter = Json.writes[Instance]
@@ -27,10 +31,6 @@ object model {
   implicit val securityGroupRuleWriter = Json.writes[Rule]
   implicit val securityGroupWriter = Json.writes[SecurityGroup]
   implicit val ownerWriter = Json.writes[Owner]
-
-  implicit val originWriter = new Writes[Origin] {
-    def writes(o: Origin): JsValue = Json.obj("vendor" -> o.vendor, "account" -> o.account)
-  }
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {

--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"executable-jar-webapp",
             "apps":["prism::app"],
             "data":{
-                "healthcheck_paths":[ "/" ]
+                "healthcheck_paths":[ "/", "/management/healthcheck" ]
             }
         }
     }


### PR DESCRIPTION
In order to put prism behind a load balancer it needed to have a suitable healthcheck and also startup quickly. 

The security group crawling on OpenStack was fairly broken due to jClouds and took up to six minutes to crawl a tenant. This wasn't really acceptable and would mean a deploy would take over 12 minutes. The crawler has been re-written to no longer use the abstraction that jClouds provides and instead uses the underlying Nova Api in jClouds and does the translation itself.

As part of this work the origin object is now attached to each result returned in the Prism API - this needs more work to include things like the tenant ID in openstack and account number for AWS, but it is a great starting point.
