### PR TITLE
Add ability to prefix values to stages in AWS

### DIFF
--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -39,10 +39,11 @@ trait Origin {
   def toJson: JsObject = JsObject((standardFields ++ jsonFields).mapValues(Json.toJson(_)).toSeq)
 }
 
-case class AmazonOrigin(account:String, region:String, accessKey:String, resources:Set[String], accountNumber:Option[String] = None)(val secretKey:String) extends Origin {
+case class AmazonOrigin(account:String, region:String, accessKey:String, resources:Set[String], stagePrefix: Option[String], accountNumber:Option[String] = None)(val secretKey:String) extends Origin {
   lazy val vendor = "aws"
   override lazy val filterMap = Map("vendor" -> vendor, "region" -> region, "accountName" -> account)
   lazy val jCloudLocation = new LocationBuilder().scope(LocationScope.REGION).id(region).description("region").build()
+  override def transformInstance(input:Instance): Instance = stagePrefix.map(input.prefixStage).getOrElse(input)
   val jsonFields = Map("region" -> region) ++ accountNumber.map("accountNumber" -> _)
   val creds = new BasicAWSCredentials(accessKey, secretKey)
 }

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -74,7 +74,7 @@ case class AWSInstanceCollector(origin:AmazonOrigin, resource:ResourceType) exte
         tags = instance.getTags.map(t => t.getKey -> t.getValue).toMap,
         specs = InstanceSpecification(instance.getImageId, instance.getInstanceType, Option(instance.getVpcId))
       )
-    }
+    }.map(origin.transformInstance)
   }
 }
 

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -51,7 +51,8 @@ class Configuration(val application: String, val webappConfDirectory: String = "
           val accessKey = getStringProperty(name, "accessKey")
           val secretKey = getStringProperty(name, "secretKey")
           val resources = getStringPropertiesSplitByComma(name, "resources")
-          AmazonOrigin(name, region, accessKey, resources.toSet)(secretKey)
+          val stagePrefix = getStringPropertyOption(name, "stagePrefix")
+          AmazonOrigin(name, region, accessKey, resources.toSet, stagePrefix)(secretKey)
         }
     }
     object openstack extends NamedProperties(configuration, "accounts.openstack") {


### PR DESCRIPTION
This is to help with the migration of flexible content into AWS (by preventing riff-raff trying to deploy to servers in AWS)