### PR TITLE
Couple of marauder updates to go with the Prism migration

### DIFF
--- a/marauder/lib/marauder/marauder.rb
+++ b/marauder/lib/marauder/marauder.rb
@@ -1,3 +1,3 @@
 class Marauder
-	VERSION="0.6.6"
+	VERSION="0.7.0"
 end


### PR DESCRIPTION
I'm working on a larger update to Prism to migrate it into AWS. As part of this the `hardware` endpoint is being removed so this is an update to marauder to deal with the resulting 404.

At the same time I've added a longed for change to detect if there is no public address on an instance  and return the IP instead. This is really useful for working with instances inside VPCs.

I'm bumping the version to 0.7.0 due to the fact that this is essentially deprecating the hardware endpoint.