### PR TITLE
Add image crawling and endpoints

### DIFF
--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -66,7 +66,7 @@ class CollectorAgent[T<:IndexedItem](val collectors:Seq[Collector[T]], lazyStart
         startupData
       } else {
         val startupData = update(collector, Datum.empty[T](collector))
-        assert(!startupData.label.isError, s"Error occured collecting data when lazy startup is disabled: ${startupData.label}")
+        assert(!startupData.label.isError, s"Error occurred collecting data when lazy startup is disabled: ${startupData.label}")
         startupData
       }
 
@@ -75,6 +75,8 @@ class CollectorAgent[T<:IndexedItem](val collectors:Seq[Collector[T]], lazyStart
       }
       collector -> agent
     }.toMap
+
+    log.info(s"Started agent for collectors: $collectors")
   }
 
   def shutdown() {

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -2,6 +2,7 @@ package agent
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.s3.AmazonS3Client
 import play.api.libs.json.{JsValue, Json, JsObject}
 import java.net.{URI, URLConnection, URL, URLStreamHandler}
@@ -76,7 +77,7 @@ case class AmazonOrigin(account:String, region:String, credsId: String, credsPro
   override lazy val filterMap = Map("vendor" -> vendor, "region" -> region, "accountName" -> account)
   override def transformInstance(input:Instance): Instance = stagePrefix.map(input.prefixStage).getOrElse(input)
   val jsonFields = Map("region" -> region) ++ accountNumber.map("accountNumber" -> _)
-
+  val awsRegion = Region.getRegion(Regions.fromName(region))
 }
 case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String]) extends Origin with Logging {
   private val classpathHandler = new URLStreamHandler {

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -1,0 +1,70 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.model.{Filter, DescribeImagesRequest}
+import controllers.routes
+import org.joda.time.{DateTime, Duration}
+import play.api.mvc.Call
+import utils.Logging
+import collection.JavaConverters._
+import com.amazonaws.services.ec2.model.{Image => AWSImage}
+
+import scala.util.Try
+
+object ImageCollectorSet extends CollectorSet[Image](ResourceType("images", Duration.standardMinutes(15L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[Image]] = {
+    //case json:JsonOrigin => JsonInstanceCollector(json, resource)
+    case amazon:AmazonOrigin => AWSImageCollector(amazon, resource)
+  }
+}
+
+case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType) extends Collector[Image] with Logging {
+
+  val client = new AmazonEC2Client(origin.credsProvider)
+  client.setRegion(origin.awsRegion)
+
+  def crawl: Iterable[Image] = {
+    val result = client.describeImages(new DescribeImagesRequest()
+      .withFilters(new Filter("owner-id", Seq(origin.accountNumber.get).asJava)))
+    result.getImages.asScala.map { Image.fromApiData(_, origin.region) }
+  }
+}
+
+object Image {
+  def fromApiData(image: AWSImage, regionName: String): Image = {
+    Image(
+      id = s"arn:aws:ec2:$regionName::image/${image.getImageId}",
+      name = image.getName,
+      imageId = image.getImageId,
+      region = regionName,
+      description = image.getDescription,
+      tags = image.getTags.asScala.map(t => t.getKey -> t.getValue).toMap,
+      creationDate = Try(new DateTime(image.getCreationDate)).toOption,
+      state = image.getState,
+      architecture = image.getArchitecture,
+      ownerId = image.getOwnerId,
+      virtualizationType = image.getVirtualizationType,
+      hypervisor = image.getHypervisor,
+      sriovNetSupport = image.getSriovNetSupport
+    )
+  }
+}
+
+case class Image(
+                id: String,
+                name: String,
+                imageId: String,
+                region: String,
+                description: String,
+                tags: Map[String,String],
+                creationDate: Option[DateTime],
+                state: String,
+                architecture: String,
+                ownerId: String,
+                virtualizationType: String,
+                hypervisor: String,
+                sriovNetSupport: String
+                  ) extends IndexedItem {
+  def callFromId: (String) => Call = id => routes.Api.image(id)
+}

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -184,6 +184,13 @@ trait Api extends Logging {
     singleItem(Prism.ownerAgent, id)
   }
 
+  def imageList = Action.async { implicit request =>
+    itemList(Prism.imageAgent, "images")
+  }
+  def image(id:String) = Action.async { implicit request =>
+    singleItem(Prism.imageAgent, id)
+  }
+
   def roleList = summary[Instance](Prism.instanceAgent, i => i.role.map(Json.toJson(_)), "roles")
   def mainclassList = summary[Instance](Prism.instanceAgent, i => i.mainclasses.map(Json.toJson(_)), "mainclasses")
   def stackList = summary[Instance](Prism.instanceAgent, i => i.stack.map(Json.toJson(_)), "stacks")

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -9,5 +9,6 @@ object Prism {
   val dataAgent = new CollectorAgent[Data](DataCollectorSet.collectors, lazyStartup)
   val securityGroupAgent = new CollectorAgent[SecurityGroup](SecurityGroupCollectorSet.collectors, lazyStartup)
   val ownerAgent = new CollectorAgent[Owner](OwnerCollectorSet.collectors, lazyStartup)
-  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, ownerAgent)
+  val imageAgent = new CollectorAgent[Image](ImageCollectorSet.collectors, lazyStartup)
+  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, ownerAgent, imageAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -45,6 +45,8 @@ object model {
   implicit val dataWriter = Json.writes[Data]
   implicit val ownerWriter = Json.writes[Owner]
 
+  implicit val imageWriter = Json.writes[Image]
+
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {
       Json.obj(

--- a/conf/routes
+++ b/conf/routes
@@ -28,6 +28,9 @@ GET        /security-groups/:id           controllers.Api.securityGroup(id)
 GET        /owners                        controllers.Api.ownerList
 GET        /owners/:id                    controllers.Api.owner(id)
 
+GET        /images                        controllers.Api.imageList
+GET        /images/:id                    controllers.Api.image(id)
+
 GET        /data                          controllers.Api.dataList
 GET        /data/keys                     controllers.Api.dataKeysList
 GET        /data/lookup/:key              controllers.Api.dataLookup(key)


### PR DESCRIPTION
Add the crawling and exploration of AMIs to Prism.

This logic only crawls image data for those images which are owned by the account being crawled. This means that images provided by third parties such as ubuntu will not be indexed.