### PR TITLE
Separate config for indexing AMIs from normal accounts.

### DIFF
--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -20,12 +20,12 @@ object ImageCollectorSet extends CollectorSet[Image](ResourceType("images", Dura
 
 case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType) extends Collector[Image] with Logging {
 
-  val client = new AmazonEC2Client(origin.credsProvider)
+  val client = new AmazonEC2Client(origin.credentials.provider)
   client.setRegion(origin.awsRegion)
 
   def crawl: Iterable[Image] = {
     val result = client.describeImages(new DescribeImagesRequest()
-      .withFilters(new Filter("owner-id", Seq(origin.alternativeImageOwner.getOrElse(origin.accountNumber.get)).asJava)))
+      .withFilters(new Filter("owner-id", Seq(origin.accountNumber.get).asJava)))
     result.getImages.asScala.map { Image.fromApiData(_, origin.region) }
   }
 }

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -32,7 +32,7 @@ case class JsonInstanceCollector(origin:JsonOrigin, resource:ResourceType) exten
 
 case class AWSInstanceCollector(origin:AmazonOrigin, resource:ResourceType) extends Collector[Instance] with Logging {
 
-  val client = new AmazonEC2Client(origin.credsProvider)
+  val client = new AmazonEC2Client(origin.credentials.provider)
   client.setEndpoint(s"ec2.${origin.region}.amazonaws.com")
 
   def getInstances:Iterable[(Reservation, AWSInstance)] = {

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -45,7 +45,7 @@ case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType)
     )
   }
 
-  val client = new AmazonEC2Client(origin.credsProvider)
+  val client = new AmazonEC2Client(origin.credentials.provider)
   client.setEndpoint(s"ec2.${origin.region}.amazonaws.com")
 
   def crawl: Iterable[SecurityGroup] = {

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -52,9 +52,25 @@ class PrismConfiguration() extends Logging {
         val profile = subConfig.getString("profile")
         val resources:Seq[String] = subConfig.getStringSeq("resources").getOrElse(Nil)
         val stagePrefix = subConfig.getString("stagePrefix")
-        val alternativeImageOwner = subConfig.getString("alternativeImageOwner")
+        val credentials = Credentials(accessKey, role, profile)(secretKey)
         regions.map(region =>
-          AmazonOrigin(name, region, accessKey, role, profile, resources.toSet, stagePrefix, secretKey, alternativeImageOwner)
+          AmazonOrigin(name, region, resources.toSet, stagePrefix, credentials)
+        )
+      }.toList
+    }
+
+    object amis {
+      lazy val defaultRegions = configuration.getStringSeq("accounts.amis.defaultRegions").getOrElse(aws.defaultRegions)
+      val list: Seq[AmazonOrigin] = subConfigurations("accounts.amis").flatMap{ case (name, subConfig) =>
+        val regions = subConfig.getStringSeq("regions").getOrElse(defaultRegions)
+        val accessKey = subConfig.getString("accessKey")
+        val secretKey = subConfig.getString("secretKey")
+        val role = subConfig.getString("role")
+        val profile = subConfig.getString("profile")
+        val accountNumber = subConfig.getString("accountNumber")
+        val credentials = Credentials(accessKey, role, profile)(secretKey)
+        regions.map(region =>
+          AmazonOrigin.amis(name, region, accountNumber, credentials)
         )
       }.toList
     }


### PR DESCRIPTION
During the hack week I overloaded the existing config in an ugly way to pull in AMIs owned by other accounts. That approach produced misleading account numbers amongst other things - so this untangles the overloading somewhat.