### PR TITLE
Add launch configurations to the the items Prism indexes

### DIFF
--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -49,7 +49,7 @@ object LaunchConfiguration {
       instanceType = config.getInstanceType,
       keyName = config.getKeyName,
       placementTenancy = Option(config.getPlacementTenancy),
-      securityGroups = Option(config.getSecurityGroups).map(_.asScala).toList.flatten.map { sg =>
+      securityGroups = Option(config.getSecurityGroups).toList.flatMap(_.asScala).map { sg =>
         s"arn:aws:ec2:${origin.region}:${origin.accountNumber.get}:security-group/$sg"
       },
       userData = Option(config.getUserData)

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -1,0 +1,70 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
+import controllers.routes
+import org.joda.time.{DateTime, Duration}
+import play.api.mvc.Call
+import utils.Logging
+import collection.JavaConverters._
+import com.amazonaws.services.autoscaling.model.{LaunchConfiguration => AWSLaunchConfiguration, DescribeLaunchConfigurationsRequest}
+
+import scala.util.Try
+
+object LaunchConfigurationCollectorSet extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations", Duration.standardMinutes(15L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
+    case amazon:AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource)
+  }
+}
+
+case class AWSLaunchConfigurationCollector(origin:AmazonOrigin, resource:ResourceType) extends Collector[LaunchConfiguration] with Logging {
+
+  val client = new AmazonAutoScalingClient(origin.credentials.provider)
+  client.setRegion(origin.awsRegion)
+
+  def crawlWithToken(nextToken: Option[String]): Iterable[LaunchConfiguration] = {
+    val request = new DescribeLaunchConfigurationsRequest().withNextToken(nextToken.orNull)
+    val result = client.describeLaunchConfigurations(request)
+    val configs = result.getLaunchConfigurations.asScala.map { LaunchConfiguration.fromApiData(_, origin.region) }
+    Option(result.getNextToken) match {
+      case None => configs
+      case Some(token) => configs ++ crawlWithToken(Some(token))
+    }
+  }
+
+  def crawl: Iterable[LaunchConfiguration] = crawlWithToken(None)
+}
+
+object LaunchConfiguration {
+  def fromApiData(config: AWSLaunchConfiguration, regionName: String): LaunchConfiguration = {
+    LaunchConfiguration(
+      arn = config.getLaunchConfigurationARN,
+      name = config.getLaunchConfigurationName,
+      imageId = config.getImageId,
+      region = regionName,
+      instanceProfile = Option(config.getIamInstanceProfile),
+      createdTime = Try(new DateTime(config.getCreatedTime)).toOption,
+      instanceType = config.getInstanceType,
+      keyName = config.getKeyName,
+      placementTenancy = Option(config.getPlacementTenancy),
+      securityGroups = Option(config.getSecurityGroups).map(_.asScala).toList.flatten,
+      userData = Option(config.getUserData)
+    )
+  }
+}
+
+case class LaunchConfiguration(
+                  arn: String,
+                  name: String,
+                  imageId: String,
+                  region: String,
+                  instanceProfile: Option[String],
+                  createdTime: Option[DateTime],
+                  instanceType: String,
+                  keyName: String,
+                  placementTenancy: Option[String],
+                  securityGroups: List[String],
+                  userData: Option[String]
+                  ) extends IndexedItem {
+  def callFromArn: (String) => Call = arn => routes.Api.launchConfiguration(arn)
+}

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -184,6 +184,13 @@ trait Api extends Logging {
     singleItem(Prism.imageAgent, arn)
   }
 
+  def launchConfigurationList = Action.async { implicit request =>
+    itemList(Prism.launchConfigurationAgent, "launch-configurations")
+  }
+  def launchConfiguration(arn:String) = Action.async { implicit request =>
+    singleItem(Prism.launchConfigurationAgent, arn)
+  }
+
   def roleList = summary[Instance](Prism.instanceAgent, i => i.role.map(Json.toJson(_)), "roles")
   def mainclassList = summary[Instance](Prism.instanceAgent, i => i.mainclasses.map(Json.toJson(_)), "mainclasses")
   def stackList = summary[Instance](Prism.instanceAgent, i => i.stack.map(Json.toJson(_)), "stacks")

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -9,5 +9,6 @@ object Prism {
   val dataAgent = new CollectorAgent[Data](DataCollectorSet.collectors, lazyStartup)
   val securityGroupAgent = new CollectorAgent[SecurityGroup](SecurityGroupCollectorSet.collectors, lazyStartup)
   val imageAgent = new CollectorAgent[Image](ImageCollectorSet.collectors, lazyStartup)
-  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent)
+  val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet.collectors, lazyStartup)
+  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -45,6 +45,7 @@ object model {
   implicit val dataWriter = Json.writes[Data]
 
   implicit val imageWriter = Json.writes[Image]
+  implicit val launchConfigurationWriter = Json.writes[LaunchConfiguration]
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-releases"
 )
 
-val awsVersion = "1.10.46"
+val awsVersion = "1.10.54"
 
 libraryDependencies ++= Seq(
     "com.google.code.findbugs" % "jsr305" % "2.0.0",
@@ -24,6 +24,8 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-iam" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
+
     "com.gu" %% "management-play" % "8.0",
     "com.typesafe.akka" %% "akka-agent" % "2.4.1",
     "com.typesafe.akka" %% "akka-slf4j" % "2.4.1",

--- a/cloudformation/prism-role.template
+++ b/cloudformation/prism-role.template
@@ -23,7 +23,8 @@
                   "Action":[
                       "ec2:Describe*",
                       "iam:Get*",
-                      "iam:List*"
+                      "iam:List*",
+                      "autoscaling:Describe*"
                   ],
                   "Resource":"*"
              }]

--- a/cloudformation/prism-user.template
+++ b/cloudformation/prism-user.template
@@ -23,7 +23,8 @@
                   "Action":[
                       "ec2:Describe*",
                       "iam:Get*",
-                      "iam:List*"
+                      "iam:List*",
+                      "autoscaling:Describe*"
                   ],
                   "Resource":"*"
              }]

--- a/conf/routes
+++ b/conf/routes
@@ -28,6 +28,9 @@ GET        /security-groups/:arn           controllers.Api.securityGroup(arn)
 GET        /images                        controllers.Api.imageList
 GET        /images/:arn                    controllers.Api.image(arn)
 
+GET        /launch-configurations                        controllers.Api.launchConfigurationList
+GET        /launch-configurations/:arn                    controllers.Api.launchConfiguration(arn)
+
 GET        /data                          controllers.Api.dataList
 GET        /data/keys                     controllers.Api.dataKeysList
 GET        /data/lookup/:key              controllers.Api.dataLookup(key)


### PR DESCRIPTION
This adds launch configurations to the list of items that Prism indexes from each account.

Sadly prism doesn't have permission to call this at present so we must update the cloudformation in each account.