### PR TITLE
Fix tests when run in AWS

### DIFF
--- a/app/PrismApplicationLoader.scala
+++ b/app/PrismApplicationLoader.scala
@@ -2,14 +2,19 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.{Regions, Region}
 import conf.{AWS, FileConfiguration, DynamoConfiguration, Identity}
 import play.api.ApplicationLoader.Context
-import play.api.Configuration
+import play.api.{Mode, Configuration}
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceApplicationLoader}
 import utils.Logging
 
 class PrismApplicationLoader extends GuiceApplicationLoader() with Logging {
 
   override protected def builder(context: Context): GuiceApplicationBuilder = {
-    val identity = AWS.instance.identity.getOrElse(Identity("deploy", "prism", "DEV"))
+    val identity = {
+      context.environment.mode match {
+        case Mode.Prod => AWS.instance.identity
+        case _ => None
+      }
+    }.getOrElse(Identity("deploy", "prism", "DEV"))
 
     log.info(s"Getting config for $identity")
 


### PR DESCRIPTION
The Prism build has been failing since TeamCity was moved to AWS. This was because it was assuming that the tests would be run in a non-AWS environment and this was no longer true.

I've changed the code to check the mode of the play application.