### PR TITLE
Adopt new riff-raff.yaml format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import scala.language.postfixOps
+
 name := "prism"
 
 version := "1.0-SNAPSHOT"
@@ -46,8 +48,10 @@ lazy val root = (project in file("."))
     riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV"),
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffArtifactResources ++=
-      (baseDirectory.value / "cloudformation" ***) pair
-        rebase(baseDirectory.value / "cloudformation", "packages/cloudformation/")
+    riffRaffArtifactResources := Seq(
+      riffRaffPackageType.value ->
+        s"${riffRaffPackageName.value}/${riffRaffPackageType.value.getName}",
+      baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml"
+    )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ logLevel := Level.Warn
 // The Typesafe repository 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,7 @@
+deployments:
+  prism:
+    type: autoscaling
+    stacks: [deploy]
+    parameters:
+      bucket: deploy-tools-dist
+      publicReadAcl: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,7 +1,8 @@
+regions: [eu-west-1]
+stacks: [deploy]
 deployments:
   prism:
     type: autoscaling
-    stacks: [deploy]
     parameters:
       bucket: deploy-tools-dist
       publicReadAcl: false


### PR DESCRIPTION
This is a kludge to make the prism build output a new format build prior to updating the SBT riff-raff plugin.