### PR TITLE
Add s3 buckets to the the items Prism indexes

### DIFF
--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -1,0 +1,63 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.s3.AmazonS3Client
+import controllers.routes
+import org.joda.time.{DateTime, Duration}
+import play.api.mvc.Call
+import utils.Logging
+import collection.JavaConverters._
+import com.amazonaws.services.s3.model.{Bucket => AWSBucket, ListBucketsRequest}
+
+import scala.util.Try
+
+object BucketCollectorSet extends CollectorSet[Bucket](ResourceType("bucket", Duration.standardMinutes(15L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[Bucket]] = {
+    case amazon: AmazonOrigin => AWSBucketCollector(amazon, resource)
+  }
+}
+
+case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Bucket] with Logging {
+
+  val client = new AmazonS3Client(origin.credentials.provider)
+  client.setRegion(origin.awsRegion)
+
+  def crawl: Iterable[Bucket] = {
+    val request = new ListBucketsRequest()
+    client.listBuckets(request).asScala.map {
+      Bucket.fromApiData(_, client)
+    }
+  }
+}
+
+object Bucket {
+
+  private def arn(bucketName: String) = s"arn:aws:s3:::$bucketName" 
+
+  def fromApiData(bucket: AWSBucket, client: AmazonS3Client): Bucket = {
+    val bucketName = bucket.getName
+    Bucket(
+      arn = arn(bucketName),
+      name = bucketName,
+      region = client.getBucketLocation(bucket.getName),
+      createdTime = Try(new DateTime(bucket.getCreationDate)).toOption
+    )
+  }
+}
+
+case class Bucket(
+  arn: String,
+  name: String,
+  region: String,
+  createdTime: Option[DateTime]
+  /*  
+      Other properties we may add in the future: 
+
+      Policy                   -> client.getBucketPolicy(String bucketName)
+      ReplicationConfiguration -> client.getBucketReplicationConfiguration(String bucketName)
+      TaggingConfiguration     -> client.getBucketTaggingConfiguration(String bucketName)
+  */
+
+) extends IndexedItem {
+  def callFromArn: (String) => Call = arn => routes.Api.bucket(arn)
+}

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -50,14 +50,6 @@ case class Bucket(
   name: String,
   region: String,
   createdTime: Option[DateTime]
-  /*  
-      Other properties we may add in the future: 
-
-      Policy                   -> client.getBucketPolicy(String bucketName)
-      ReplicationConfiguration -> client.getBucketReplicationConfiguration(String bucketName)
-      TaggingConfiguration     -> client.getBucketTaggingConfiguration(String bucketName)
-  */
-
 ) extends IndexedItem {
-  def callFromArn: (String) => Call = arn => routes.Api.bucket(arn)
+  override def callFromArn: (String) => Call = arn => routes.Api.bucket(arn)
 }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -198,6 +198,13 @@ trait Api extends Logging {
     singleItem(Prism.serverCertificateAgent, arn)
   }
 
+  def bucketList = Action.async { implicit request =>
+    itemList(Prism.bucketAgent, "bucket")
+  }
+  def bucket(arn:String) = Action.async { implicit request =>
+    singleItem(Prism.bucketAgent, arn)
+  }
+
   def roleList = summary[Instance](Prism.instanceAgent, i => i.role.map(Json.toJson(_)), "roles")
   def mainclassList = summary[Instance](Prism.instanceAgent, i => i.mainclasses.map(Json.toJson(_)), "mainclasses")
   def stackList = summary[Instance](Prism.instanceAgent, i => i.stack.map(Json.toJson(_)), "stacks")

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -11,5 +11,6 @@ object Prism {
   val imageAgent = new CollectorAgent[Image](ImageCollectorSet.collectors, lazyStartup)
   val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet.collectors, lazyStartup)
   val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet.collectors, lazyStartup)
-  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent, serverCertificateAgent)
+  val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet.collectors, lazyStartup)
+  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent, serverCertificateAgent, bucketAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -47,6 +47,7 @@ object model {
   implicit val imageWriter = Json.writes[Image]
   implicit val launchConfigurationWriter = Json.writes[LaunchConfiguration]
   implicit val serverCertificateWriter = Json.writes[ServerCertificate]
+  implicit val bucketWriter = Json.writes[Bucket]
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "prism"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.8"
 
 scalacOptions ++= Seq("-unchecked", "-optimise", "-deprecation",
   "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings",

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-iam" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
 
     "com.gu" %% "management-play" % "8.0",
     "com.typesafe.akka" %% "akka-agent" % "2.4.1",

--- a/cloudformation/prism-role.template
+++ b/cloudformation/prism-role.template
@@ -25,7 +25,8 @@
                       "iam:Get*",
                       "iam:List*",
                       "autoscaling:Describe*",
-                      "s3:List*"
+                      "s3:ListAllMyBuckets",
+                      "s3:GetBucketLocation"
                   ],
                   "Resource":"*"
              }]

--- a/cloudformation/prism-role.template
+++ b/cloudformation/prism-role.template
@@ -24,7 +24,8 @@
                       "ec2:Describe*",
                       "iam:Get*",
                       "iam:List*",
-                      "autoscaling:Describe*"
+                      "autoscaling:Describe*",
+                      "s3:List*"
                   ],
                   "Resource":"*"
              }]

--- a/cloudformation/prism-user.template
+++ b/cloudformation/prism-user.template
@@ -25,7 +25,8 @@
                       "iam:Get*",
                       "iam:List*",
                       "autoscaling:Describe*",
-                      "s3:List*"
+                      "s3:ListAllMyBuckets",
+                      "s3:GetBucketLocation"
                   ],
                   "Resource":"*"
              }]

--- a/cloudformation/prism-user.template
+++ b/cloudformation/prism-user.template
@@ -24,7 +24,8 @@
                       "ec2:Describe*",
                       "iam:Get*",
                       "iam:List*",
-                      "autoscaling:Describe*"
+                      "autoscaling:Describe*",
+                      "s3:List*"
                   ],
                   "Resource":"*"
              }]

--- a/conf/routes
+++ b/conf/routes
@@ -34,7 +34,7 @@ GET        /launch-configurations/:arn    controllers.Api.launchConfiguration(ar
 GET        /server-certificates           controllers.Api.serverCertificateList
 GET        /server-certificates/:arn      controllers.Api.serverCertificate(arn)
 
-GET        /bucket                        controllers.Api.bucketList
+GET        /buckets                       controllers.Api.bucketList
 GET        /buckets/:arn                  controllers.Api.bucket(arn)
 
 GET        /data                          controllers.Api.dataList

--- a/conf/routes
+++ b/conf/routes
@@ -20,24 +20,27 @@ GET        /instances/regions             controllers.Api.regionList
 GET        /instances/vendors             controllers.Api.vendorList
 GET        /instances/roles               controllers.Api.roleList
 GET        /instances/mainclasses         controllers.Api.mainclassList
-GET        /instances/:arn                 controllers.Api.instance(arn)
+GET        /instances/:arn                controllers.Api.instance(arn)
 
 GET        /security-groups               controllers.Api.securityGroupList
-GET        /security-groups/:arn           controllers.Api.securityGroup(arn)
+GET        /security-groups/:arn          controllers.Api.securityGroup(arn)
 
 GET        /images                        controllers.Api.imageList
-GET        /images/:arn                    controllers.Api.image(arn)
+GET        /images/:arn                   controllers.Api.image(arn)
 
-GET        /launch-configurations                        controllers.Api.launchConfigurationList
-GET        /launch-configurations/:arn                    controllers.Api.launchConfiguration(arn)
+GET        /launch-configurations         controllers.Api.launchConfigurationList
+GET        /launch-configurations/:arn    controllers.Api.launchConfiguration(arn)
 
-GET        /server-certificates                        controllers.Api.serverCertificateList
-GET        /server-certificates/:arn                    controllers.Api.serverCertificate(arn)
+GET        /server-certificates           controllers.Api.serverCertificateList
+GET        /server-certificates/:arn      controllers.Api.serverCertificate(arn)
+
+GET        /bucket                        controllers.Api.bucketList
+GET        /buckets/:arn                  controllers.Api.bucket(arn)
 
 GET        /data                          controllers.Api.dataList
 GET        /data/keys                     controllers.Api.dataKeysList
 GET        /data/lookup/:key              controllers.Api.dataLookup(key)
-GET        /data/:arn                      controllers.Api.data(arn)
+GET        /data/:arn                     controllers.Api.data(arn)
 
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file                  controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
This adds s3 buckets to the list of items that Prism indexes from each account.

Sadly prism doesn't have permission to call this at present so we must update the cloudformation in each account.

Added a commit to update to scala `2.11.8` as well.

Fixes #33 

@sihil 