### PR TITLE
Fetch and list reservation information.

### DIFF
--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -10,7 +10,7 @@ import play.api.mvc.Call
 import controllers.routes
 import scala.language.postfixOps
 import com.amazonaws.services.ec2.AmazonEC2Client
-import com.amazonaws.services.ec2.model.{Instance => AWSInstance, Reservation}
+import com.amazonaws.services.ec2.model.{Instance => AWSInstance, Reservation => AWSReservation}
 import agent._
 
 object InstanceCollectorSet extends CollectorSet[Instance](ResourceType("instance", Duration.standardMinutes(15L))) {
@@ -35,7 +35,7 @@ case class AWSInstanceCollector(origin:AmazonOrigin, resource:ResourceType) exte
   val client = new AmazonEC2Client(origin.credentials.provider)
   client.setEndpoint(s"ec2.${origin.region}.amazonaws.com")
 
-  def getInstances:Iterable[(Reservation, AWSInstance)] = {
+  def getInstances:Iterable[(AWSReservation, AWSInstance)] = {
     client.describeInstances().getReservations.flatMap(r => r.getInstances.map(r -> _))
   }
 

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -11,7 +11,7 @@ import utils.Logging
 import collection.JavaConverters._
 import scala.util.Try
 
-object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("reservations", Duration.standardMinutes(15L))) {
+object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("reservation", Duration.standardMinutes(15L))) {
   val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
     case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource)
   }

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -1,0 +1,56 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.model.{DescribeReservedInstancesRequest, ReservedInstances}
+import controllers.routes
+import org.joda.time.{DateTime, Duration}
+import play.api.mvc.Call
+import utils.Logging
+
+import collection.JavaConverters._
+import scala.util.Try
+
+object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("bucket", Duration.standardMinutes(15L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
+    case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource)
+  }
+}
+
+case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Reservation] with Logging {
+
+  val client = new AmazonEC2Client(origin.credentials.provider)
+  client.setRegion(origin.awsRegion)
+
+  def crawl: Iterable[Reservation] = {
+    client.describeReservedInstances(new DescribeReservedInstancesRequest()).getReservedInstances.asScala.map {
+      Reservation.fromApiData
+    }
+  }
+}
+
+case class Reservation(
+  key: String,
+  region: String,
+  instanceType: String,
+  instanceCount: Int,
+  startTime: Option[DateTime],
+  endTime: Option[DateTime]
+) extends IndexedItem {
+  override def arn: String = s"arn:gu:reservation:key/$key"
+  override def callFromArn: (String) => Call = arn => routes.Api.reservation(arn)
+
+}
+
+object Reservation {
+  def fromApiData(reservationInstance: ReservedInstances): Reservation = {
+    Reservation(
+      key = reservationInstance.getReservedInstancesId,
+      region = reservationInstance.getAvailabilityZone,
+      instanceType = reservationInstance.getInstanceType,
+      instanceCount = reservationInstance.getInstanceCount,
+      startTime = Try(new DateTime(reservationInstance.getStart)).toOption,
+      endTime = Try(new DateTime(reservationInstance.getEnd)).toOption
+    )
+  }
+}

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -11,7 +11,7 @@ import utils.Logging
 import collection.JavaConverters._
 import scala.util.Try
 
-object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("bucket", Duration.standardMinutes(15L))) {
+object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("reservations", Duration.standardMinutes(15L))) {
   val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
     case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource)
   }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -205,6 +205,13 @@ trait Api extends Logging {
     singleItem(Prism.bucketAgent, arn)
   }
 
+  def reservationList = Action.async { implicit request =>
+    itemList(Prism.reservationAgent, "reservations")
+  }
+  def reservation(arn:String) = Action.async { implicit request =>
+    singleItem(Prism.reservationAgent, arn)
+  }
+
   def roleList = summary[Instance](Prism.instanceAgent, i => i.role.map(Json.toJson(_)), "roles")
   def mainclassList = summary[Instance](Prism.instanceAgent, i => i.mainclasses.map(Json.toJson(_)), "mainclasses")
   def stackList = summary[Instance](Prism.instanceAgent, i => i.stack.map(Json.toJson(_)), "stacks")

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -206,7 +206,7 @@ trait Api extends Logging {
   }
 
   def reservationList = Action.async { implicit request =>
-    itemList(Prism.reservationAgent, "reservations")
+    itemList(Prism.reservationAgent, "reservation")
   }
   def reservation(arn:String) = Action.async { implicit request =>
     singleItem(Prism.reservationAgent, arn)

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -12,5 +12,7 @@ object Prism {
   val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet.collectors, lazyStartup)
   val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet.collectors, lazyStartup)
   val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet.collectors, lazyStartup)
-  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent, serverCertificateAgent, bucketAgent)
+  val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet.collectors, lazyStartup)
+  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
+    serverCertificateAgent, bucketAgent, reservationAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -48,7 +48,10 @@ object model {
   implicit val launchConfigurationWriter = Json.writes[LaunchConfiguration]
   implicit val serverCertificateWriter = Json.writes[ServerCertificate]
   implicit val bucketWriter = Json.writes[Bucket]
-  implicit val reservationWriter = Json.writes[Reservation]
+  implicit val reservationWriter: Writes[Reservation] = {
+    implicit val recurringCharge = Json.writes[RecurringCharge]
+    Json.writes[Reservation]
+  }
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -48,6 +48,7 @@ object model {
   implicit val launchConfigurationWriter = Json.writes[LaunchConfiguration]
   implicit val serverCertificateWriter = Json.writes[ServerCertificate]
   implicit val bucketWriter = Json.writes[Bucket]
+  implicit val reservationWriter = Json.writes[Reservation]
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {

--- a/conf/routes
+++ b/conf/routes
@@ -37,6 +37,9 @@ GET        /server-certificates/:arn      controllers.Api.serverCertificate(arn)
 GET        /buckets                       controllers.Api.bucketList
 GET        /buckets/:arn                  controllers.Api.bucket(arn)
 
+GET        /reservations                  controllers.Api.reservationList
+GET        /reservations/:arn             controllers.Api.reservation(arn)
+
 GET        /data                          controllers.Api.dataList
 GET        /data/keys                     controllers.Api.dataKeysList
 GET        /data/lookup/:key              controllers.Api.dataLookup(key)


### PR DESCRIPTION
This adds reservation information to the list of items that Prism indexes from each account.

I plan to use this data and the `/instances` endpoint to make decisions on reservations / on-demand for tools accounts.