### PR TITLE
Availability zone should be group (as per /instance endpoint) and not region

### DIFF
--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -32,7 +32,7 @@ case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType)
 case class Reservation(
   arn: String,
   id: String,
-  group: String,
+  availabilityZone: String,
   instanceType: String,
   instanceCount: Int,
   productDescription: String,
@@ -53,13 +53,13 @@ case class Reservation(
 
 object Reservation {
   def fromApiData(reservationInstance: ReservedInstances, origin: AmazonOrigin): Reservation = {
-    val group = reservationInstance.getAvailabilityZone
-    val arn = s"arn:aws:ec2:$group:${origin.accountNumber.getOrElse("")}:reservation/${reservationInstance.getReservedInstancesId}"
+    val availabilityZone = reservationInstance.getAvailabilityZone
+    val arn = s"arn:aws:ec2:$availabilityZone:${origin.accountNumber.getOrElse("")}:reservation/${reservationInstance.getReservedInstancesId}"
     val recurringCharges = reservationInstance.getRecurringCharges.asScala.map(RecurringCharge.fromApiData(_)).toList
     Reservation(
       arn = arn,
       id = reservationInstance.getReservedInstancesId,
-      group = group,
+      availabilityZone = availabilityZone,
       instanceType = reservationInstance.getInstanceType,
       instanceCount = reservationInstance.getInstanceCount,
       productDescription = reservationInstance.getProductDescription,

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -32,7 +32,7 @@ case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType)
 case class Reservation(
   arn: String,
   id: String,
-  region: String,
+  group: String,
   instanceType: String,
   instanceCount: Int,
   productDescription: String,
@@ -53,13 +53,13 @@ case class Reservation(
 
 object Reservation {
   def fromApiData(reservationInstance: ReservedInstances, origin: AmazonOrigin): Reservation = {
-    val region = reservationInstance.getAvailabilityZone
-    val arn = s"arn:aws:ec2:$region:${origin.accountNumber.getOrElse("")}:reservation/${reservationInstance.getReservedInstancesId}"
+    val group = reservationInstance.getAvailabilityZone
+    val arn = s"arn:aws:ec2:$group:${origin.accountNumber.getOrElse("")}:reservation/${reservationInstance.getReservedInstancesId}"
     val recurringCharges = reservationInstance.getRecurringCharges.asScala.map(RecurringCharge.fromApiData(_)).toList
     Reservation(
       arn = arn,
       id = reservationInstance.getReservedInstancesId,
-      region = region,
+      group = group,
       instanceType = reservationInstance.getInstanceType,
       instanceCount = reservationInstance.getInstanceCount,
       productDescription = reservationInstance.getProductDescription,


### PR DESCRIPTION
In https://github.com/guardian/prism/pull/37 I incorrectly put the AZ group as region, I've followed the `/instance` endpoint and renamed it to group.
