### PR TITLE
Add ACM certificates endpoint to Prism

### DIFF
--- a/app/PrismApplicationLoader.scala
+++ b/app/PrismApplicationLoader.scala
@@ -21,7 +21,7 @@ class PrismApplicationLoader extends GuiceApplicationLoader() with Logging {
     val extraConfigs = List(
       DynamoConfiguration(
         new DefaultAWSCredentialsProviderChain(),
-        Region.getRegion(Regions.EU_WEST_1),
+        Regions.EU_WEST_1,
         identity
       ),
       FileConfiguration(identity)

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -1,0 +1,114 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.certificatemanager.AWSCertificateManagerClientBuilder
+import com.amazonaws.services.certificatemanager.model.{CertificateDetail, DescribeCertificateRequest, ListCertificatesRequest, RenewalSummary, DomainValidation => AwsDomainValidation}
+import controllers.routes
+import org.joda.time.{DateTime, Duration}
+import play.api.mvc.Call
+import utils.Logging
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acm-certificates", Duration.standardMinutes(14L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
+    case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource)
+  }
+}
+
+case class AWSAcmCertificateCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[AcmCertificate] with Logging {
+
+  val client = AWSCertificateManagerClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
+
+  private def crawlWithMarker(token: Option[String]): Iterable[AcmCertificate] = {
+    val request = new ListCertificatesRequest().withNextToken(token.orNull)
+    val result = client.listCertificates(request)
+    val configs = result.getCertificateSummaryList.asScala.map { cert =>
+      val requestDetails = new DescribeCertificateRequest().withCertificateArn(cert.getCertificateArn)
+      val resultDetails = client.describeCertificate(requestDetails)
+      AcmCertificate.fromApiData(resultDetails.getCertificate, origin)
+    }
+    Option(result.getNextToken) match {
+      case None => configs
+      case t@Some(_) => configs ++ crawlWithMarker(t)
+    }
+  }
+
+  def crawl: Iterable[AcmCertificate] = crawlWithMarker(None)
+}
+
+case class DomainValidation(
+                             domainName: String,
+                             validationEmails: List[String],
+                             validationDomain: String,
+                             validationStatus: String
+                           )
+
+object DomainValidation {
+  def fromApiData(dv: AwsDomainValidation): DomainValidation = {
+    DomainValidation(
+      dv.getDomainName,
+      dv.getValidationEmails.asScala.toList,
+      dv.getValidationDomain,
+      dv.getValidationStatus
+    )
+  }
+}
+
+case class RenewalInfo(renewalStatus: String, domainValidationOptions: List[DomainValidation])
+
+object RenewalInfo {
+  def fromApiData(ri: RenewalSummary): RenewalInfo = {
+    RenewalInfo(ri.getRenewalStatus, ri.getDomainValidationOptions.asScala.map(DomainValidation.fromApiData).toList)
+  }
+}
+
+object AcmCertificate {
+  def fromApiData(cert: CertificateDetail, origin: AmazonOrigin) = AcmCertificate(
+    arn = cert.getCertificateArn,
+    domainName = cert.getDomainName,
+    subjectAlternativeNames = cert.getSubjectAlternativeNames.asScala.toList,
+    certificateType = cert.getType,
+    status = cert.getStatus,
+    issuer = cert.getIssuer,
+    inUseBy = cert.getInUseBy.asScala.toList,
+    notBefore = Option(cert.getNotBefore).flatMap(dt => Try(new DateTime(dt)).toOption),
+    notAfter = Option(cert.getNotAfter).flatMap(dt => Try(new DateTime(dt)).toOption),
+    createdAt = Option(cert.getCreatedAt).flatMap(dt => Try(new DateTime(dt)).toOption),
+    issuedAt = Option(cert.getIssuedAt).flatMap(dt => Try(new DateTime(dt)).toOption),
+    failureReason = Option(cert.getFailureReason),
+    subject = cert.getSubject,
+    keyAlgorithm = cert.getKeyAlgorithm,
+    signatureAlgorithm = cert.getSignatureAlgorithm,
+    serial = cert.getSerial,
+    domainValidationOptions = cert.getDomainValidationOptions.asScala.toList.map(DomainValidation.fromApiData),
+    renewalStatus = Option(cert.getRenewalSummary).map(RenewalInfo.fromApiData)
+  )
+}
+
+case class AcmCertificate(
+                              arn: String,
+                              domainName: String,
+                              subjectAlternativeNames: List[String],
+                              certificateType: String,
+                              status: String,
+                              issuer: String,
+                              inUseBy: List[String],
+                              notBefore: Option[DateTime],
+                              notAfter: Option[DateTime],
+                              createdAt: Option[DateTime],
+                              issuedAt: Option[DateTime],
+                              failureReason: Option[String],
+                              subject: String,
+                              keyAlgorithm: String,
+                              signatureAlgorithm: String,
+                              serial: String,
+                              domainValidationOptions: List[DomainValidation],
+                              renewalStatus: Option[RenewalInfo]
+                            ) extends IndexedItem {
+  def callFromArn: (String) => Call = arn => routes.Api.acmCertificate(arn)
+}

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -1,12 +1,13 @@
 package collectors
 
 import agent._
-import com.amazonaws.services.ec2.AmazonEC2Client
-import com.amazonaws.services.ec2.model.{Filter, DescribeImagesRequest}
+import com.amazonaws.services.ec2.{AmazonEC2Client, AmazonEC2ClientBuilder}
+import com.amazonaws.services.ec2.model.{DescribeImagesRequest, Filter}
 import controllers.routes
 import org.joda.time.{DateTime, Duration}
 import play.api.mvc.Call
 import utils.Logging
+
 import collection.JavaConverters._
 import com.amazonaws.services.ec2.model.{Image => AWSImage}
 
@@ -20,8 +21,10 @@ object ImageCollectorSet extends CollectorSet[Image](ResourceType("images", Dura
 
 case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType) extends Collector[Image] with Logging {
 
-  val client = new AmazonEC2Client(origin.credentials.provider)
-  client.setRegion(origin.awsRegion)
+  val client = AmazonEC2ClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
 
   def crawl: Iterable[Image] = {
     val result = client.describeImages(new DescribeImagesRequest()

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -1,13 +1,14 @@
 package collectors
 
 import agent._
-import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
+import com.amazonaws.services.autoscaling.{AmazonAutoScalingClient, AmazonAutoScalingClientBuilder}
 import controllers.routes
 import org.joda.time.{DateTime, Duration}
 import play.api.mvc.Call
 import utils.Logging
+
 import collection.JavaConverters._
-import com.amazonaws.services.autoscaling.model.{LaunchConfiguration => AWSLaunchConfiguration, DescribeLaunchConfigurationsRequest}
+import com.amazonaws.services.autoscaling.model.{DescribeLaunchConfigurationsRequest, LaunchConfiguration => AWSLaunchConfiguration}
 
 import scala.util.Try
 
@@ -19,8 +20,10 @@ object LaunchConfigurationCollectorSet extends CollectorSet[LaunchConfiguration]
 
 case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[LaunchConfiguration] with Logging {
 
-  val client = new AmazonAutoScalingClient(origin.credentials.provider)
-  client.setRegion(origin.awsRegion)
+  val client = AmazonAutoScalingClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
 
   def crawlWithToken(nextToken: Option[String]): Iterable[LaunchConfiguration] = {
     val request = new DescribeLaunchConfigurationsRequest().withNextToken(nextToken.orNull)

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -1,14 +1,14 @@
 package collectors
 
 import agent._
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder
+import com.amazonaws.services.identitymanagement.model.{ListServerCertificatesRequest, ServerCertificateMetadata}
 import controllers.routes
 import org.joda.time.{DateTime, Duration}
 import play.api.mvc.Call
 import utils.Logging
-import collection.JavaConverters._
-import com.amazonaws.services.identitymanagement.model.{ServerCertificateMetadata, ListServerCertificatesRequest}
 
+import scala.collection.JavaConverters._
 import scala.util.Try
 
 object ServerCertificateCollectorSet extends CollectorSet[ServerCertificate](ResourceType("server-certificates", Duration.standardMinutes(14L))) {
@@ -19,8 +19,10 @@ object ServerCertificateCollectorSet extends CollectorSet[ServerCertificate](Res
 
 case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[ServerCertificate] with Logging {
 
-  val client = new AmazonIdentityManagementClient(origin.credentials.provider)
-  client.setRegion(origin.awsRegion)
+  val client = AmazonIdentityManagementClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
 
   private def crawlWithMarker(marker: Option[String]): Iterable[ServerCertificate] = {
     val request = new ListServerCertificatesRequest().withMarker(marker.orNull)

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -52,10 +52,10 @@ class PrismConfiguration() extends Logging {
         val profile = subConfig.getString("profile")
         val resources:Seq[String] = subConfig.getStringSeq("resources").getOrElse(Nil)
         val stagePrefix = subConfig.getString("stagePrefix")
-        val credentials = Credentials(accessKey, role, profile)(secretKey)
-        regions.map(region =>
+        regions.map { region =>
+          val credentials = Credentials(accessKey, role, profile, region)(secretKey)
           AmazonOrigin(name, region, resources.toSet, stagePrefix, credentials)
-        )
+        }
       }.toList
     }
 
@@ -68,10 +68,10 @@ class PrismConfiguration() extends Logging {
         val role = subConfig.getString("role")
         val profile = subConfig.getString("profile")
         val accountNumber = subConfig.getString("accountNumber")
-        val credentials = Credentials(accessKey, role, profile)(secretKey)
-        regions.map(region =>
+        regions.map { region =>
+          val credentials = Credentials(accessKey, role, profile, region)(secretKey)
           AmazonOrigin.amis(name, region, accountNumber, credentials)
-        )
+        }
       }.toList
     }
 

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -198,6 +198,13 @@ trait Api extends Logging {
     singleItem(Prism.serverCertificateAgent, arn)
   }
 
+  def acmCertificateList = Action.async { implicit request =>
+    itemList(Prism.acmCertificateAgent, "acm-certificates")
+  }
+  def acmCertificate(arn:String) = Action.async { implicit request =>
+    singleItem(Prism.acmCertificateAgent, arn)
+  }
+
   def bucketList = Action.async { implicit request =>
     itemList(Prism.bucketAgent, "bucket")
   }

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -11,8 +11,9 @@ object Prism {
   val imageAgent = new CollectorAgent[Image](ImageCollectorSet.collectors, lazyStartup)
   val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet.collectors, lazyStartup)
   val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet.collectors, lazyStartup)
+  val acmCertificateAgent = new CollectorAgent[AcmCertificate](AmazonCertificateCollectorSet.collectors, lazyStartup)
   val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet.collectors, lazyStartup)
   val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet.collectors, lazyStartup)
   val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
-    serverCertificateAgent, bucketAgent, reservationAgent)
+    serverCertificateAgent, acmCertificateAgent, bucketAgent, reservationAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -54,6 +54,10 @@ object model {
     Json.writes[Reservation]
   }
 
+  implicit val domainValidationWriter = Json.writes[DomainValidation]
+  implicit val renewalInfoWriter = Json.writes[RenewalInfo]
+  implicit val acmCertificateWriter = Json.writes[AcmCertificate]
+
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {
       Json.obj(

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-releases"
 )
 
-val awsVersion = "1.10.54"
+val awsVersion = "1.11.150"
 
 libraryDependencies ++= Seq(
     "com.google.code.findbugs" % "jsr305" % "2.0.0",
@@ -28,6 +28,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-acm" % awsVersion,
 
     "com.gu" %% "management-play" % "8.0",
     "com.typesafe.akka" %% "akka-agent" % "2.4.1",

--- a/conf/routes
+++ b/conf/routes
@@ -2,52 +2,55 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET        /                              controllers.Application.index
+GET        /                                  controllers.Application.index
 
 # API V1
-GET        /sources                       controllers.Api.sources
-GET        /management/healthcheck        controllers.Api.healthCheck
-GET        /management/config             controllers.Application.config
+GET        /sources                           controllers.Api.sources
+GET        /management/healthcheck            controllers.Api.healthCheck
+GET        /management/config                 controllers.Application.config
 
-GET        /apps                          controllers.Api.appList
-GET        /stacks                        controllers.Api.stackList
-GET        /stages                        controllers.Api.stageList
+GET        /apps                              controllers.Api.appList
+GET        /stacks                            controllers.Api.stackList
+GET        /stages                            controllers.Api.stageList
 
-GET        /find                          controllers.Api.find
+GET        /find                              controllers.Api.find
 
-GET        /instances                     controllers.Api.instanceList
-GET        /instances/regions             controllers.Api.regionList
-GET        /instances/vendors             controllers.Api.vendorList
-GET        /instances/roles               controllers.Api.roleList
-GET        /instances/mainclasses         controllers.Api.mainclassList
-GET        /instances/:arn                controllers.Api.instance(arn)
+GET        /instances                         controllers.Api.instanceList
+GET        /instances/regions                 controllers.Api.regionList
+GET        /instances/vendors                 controllers.Api.vendorList
+GET        /instances/roles                   controllers.Api.roleList
+GET        /instances/mainclasses             controllers.Api.mainclassList
+GET        /instances/:arn                    controllers.Api.instance(arn)
 
-GET        /security-groups               controllers.Api.securityGroupList
-GET        /security-groups/:arn          controllers.Api.securityGroup(arn)
+GET        /security-groups                   controllers.Api.securityGroupList
+GET        /security-groups/:arn              controllers.Api.securityGroup(arn)
 
-GET        /images                        controllers.Api.imageList
-GET        /images/:arn                   controllers.Api.image(arn)
+GET        /images                            controllers.Api.imageList
+GET        /images/:arn                       controllers.Api.image(arn)
 
-GET        /launch-configurations         controllers.Api.launchConfigurationList
-GET        /launch-configurations/:arn    controllers.Api.launchConfiguration(arn)
+GET        /launch-configurations             controllers.Api.launchConfigurationList
+GET        /launch-configurations/:arn        controllers.Api.launchConfiguration(arn)
 
-GET        /server-certificates           controllers.Api.serverCertificateList
-GET        /server-certificates/:arn      controllers.Api.serverCertificate(arn)
+GET        /server-certificates               controllers.Api.serverCertificateList
+GET        /server-certificates/:arn          controllers.Api.serverCertificate(arn)
 
-GET        /buckets                       controllers.Api.bucketList
-GET        /buckets/:arn                  controllers.Api.bucket(arn)
+GET        /acm-certificates                  controllers.Api.acmCertificateList
+GET        /acm-certificates/:arn             controllers.Api.acmCertificate(arn)
 
-GET        /reservations                  controllers.Api.reservationList
-GET        /reservations/:arn             controllers.Api.reservation(arn)
+GET        /buckets                           controllers.Api.bucketList
+GET        /buckets/:arn                      controllers.Api.bucket(arn)
 
-GET        /data                          controllers.Api.dataList
-GET        /data/keys                     controllers.Api.dataKeysList
-GET        /data/lookup/:key              controllers.Api.dataLookup(key)
-GET        /data/:arn                     controllers.Api.data(arn)
+GET        /reservations                      controllers.Api.reservationList
+GET        /reservations/:arn                 controllers.Api.reservation(arn)
+
+GET        /data                              controllers.Api.dataList
+GET        /data/keys                         controllers.Api.dataKeysList
+GET        /data/lookup/:key                  controllers.Api.dataLookup(key)
+GET        /data/:arn                         controllers.Api.data(arn)
 
 # Map static resources from the /public folder to the /assets URL path
-GET        /assets/*file                  controllers.Assets.at(path="/public", file)
+GET        /assets/*file                      controllers.Assets.at(path="/public", file)
 
-GET        /owners                        controllers.OwnerApi.ownerList
-GET        /owners/forStack/:stack        controllers.OwnerApi.ownerForStack(stack)
-GET        /owners/:id                    controllers.OwnerApi.owner(id)
+GET        /owners                            controllers.OwnerApi.ownerList
+GET        /owners/forStack/:stack            controllers.OwnerApi.ownerForStack(stack)
+GET        /owners/:id                        controllers.OwnerApi.owner(id)


### PR DESCRIPTION
Expiring ACM certificates are becoming a problem to it makes sense to have a way of easily identifying certificates that are close to expiring. Adding an endpoint to prism makes this somewhat easier to do at a departmental level.

The new collector needs a couple of new permissions. This has been added to the Prism role CFN template over at https://github.com/guardian/deploy-tools-platform/pull/61. This needs to be merged / rolled out to all of the accounts before this can be deployed.

TODO:
 - [x] Updated prism CFN template rolled out to all accounts