### PR TITLE
Deal with null from getValidationEmails

### DIFF
--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -52,7 +52,7 @@ object DomainValidation {
   def fromApiData(dv: AwsDomainValidation): DomainValidation = {
     DomainValidation(
       dv.getDomainName,
-      dv.getValidationEmails.asScala.toList,
+      Option(dv.getValidationEmails).toList.flatMap(_.asScala.toList),
       dv.getValidationDomain,
       dv.getValidationStatus
     )

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -11,7 +11,7 @@ import utils.Logging
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acm-certificates", Duration.standardMinutes(14L))) {
+object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acmCertificates", Duration.standardMinutes(15L))) {
   val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
     case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource)
   }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -199,7 +199,7 @@ trait Api extends Logging {
   }
 
   def acmCertificateList = Action.async { implicit request =>
-    itemList(Prism.acmCertificateAgent, "acm-certificates")
+    itemList(Prism.acmCertificateAgent, "acmCertificates")
   }
   def acmCertificate(arn:String) = Action.async { implicit request =>
     singleItem(Prism.acmCertificateAgent, arn)


### PR DESCRIPTION
In the real world it seems that `getValidationEmails` can return `null`. This wraps it in `Option` and massages it appropriately.

I've also changed acm-certificates to acmCertificates as it makes jq wrangling easier.