### PR TITLE
Add account owners to the origin object

### DIFF
--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -44,17 +44,19 @@ class PrismConfiguration() extends Logging {
 
     object aws {
       lazy val defaultRegions = configuration.getStringSeq("accounts.aws.defaultRegions").getOrElse(Seq("eu-west-1"))
+      lazy val defaultOwnerId = configuration.getString("accounts.aws.defaultOwnerId")
       val list: Seq[AmazonOrigin] = subConfigurations("accounts.aws").flatMap{ case (name, subConfig) =>
         val regions = subConfig.getStringSeq("regions").getOrElse(defaultRegions)
         val accessKey = subConfig.getString("accessKey")
         val secretKey = subConfig.getString("secretKey")
         val role = subConfig.getString("role")
+        val ownerId = subConfig.getString("ownerId").orElse(defaultOwnerId)
         val profile = subConfig.getString("profile")
         val resources:Seq[String] = subConfig.getStringSeq("resources").getOrElse(Nil)
         val stagePrefix = subConfig.getString("stagePrefix")
         regions.map { region =>
           val credentials = Credentials(accessKey, role, profile, region)(secretKey)
-          AmazonOrigin(name, region, resources.toSet, stagePrefix, credentials)
+          AmazonOrigin(name, region, resources.toSet, stagePrefix, credentials, ownerId)
         }
       }.toList
     }
@@ -70,7 +72,7 @@ class PrismConfiguration() extends Logging {
         val accountNumber = subConfig.getString("accountNumber")
         regions.map { region =>
           val credentials = Credentials(accessKey, role, profile, region)(secretKey)
-          AmazonOrigin.amis(name, region, accountNumber, credentials)
+          AmazonOrigin.amis(name, region, accountNumber, credentials, ownerId = None)
         }
       }.toList
     }


### PR DESCRIPTION
Rather than trying to [retrofit](https://github.com/guardian/prism/pull/49) the account owner in the Owner endpoint, following a conversation with @sihil this is another approach where I insert the owner of the account at the Origin level.

The optional property is named `ownerId` and contains the first half of our emails addresses. It's optional as it doesn't make sense to set it for amis origins, as they're external to our department.

The property is read from the configuration, and falls back to a default, there again read from the configuration. I didn't hard-code a default mailing list to avoid pushing that publicly, we'll just have to ensure the property is present in the config.


It looks like that: 
```json
origin": {
    "accountName": "someAccount",
    "ownerId": "some.email.handle",
    "region": "eu-west-1",
    "accountNumber": "099999999999",
    "vendor": "aws",
    "credentials": "arn:aws:iam::099999999999:role/blah"
}
```

and can be seen on CODE here: https://prism.code.dev-gutools.co.uk/acm-certificates

I think I'm less mixing concepts here, so hopefully that should be more maintainable cc @jennysivapalan @TBonnin 