### PR TITLE
Add more detailed ownership for stacks

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -27,19 +27,51 @@ trait Owners {
 
 object Owners extends Owners {
 
-  override def default = Owner("phil.wills")
+  override def default = Owner("dig.dev.tooling")
 
   override def stacks: Set[(String, SSA)] = Set(
-    "dotcom.platform" -> SSA("frontend"),
-    "simon.hildrew" -> SSA("deploy"),
     "adam.fisher" -> SSA("security"),
+    "dotcom.platform" -> SSA("frontend"),
+    "dotcom.platform" -> SSA("frontend-elk"),
+    "dotcom.platform" -> SSA(stack = "discussion"),
+    "dotcom.platform" -> SSA(stack = "abacus"),
+    "dotcom.platform" -> SSA(stack = "identity"),
+    "dotcom.platform" -> SSA(stack = "identity-elk"),
+    "dig.dev.tooling" -> SSA("deploy"),
+    "dig.dev.tooling" -> SSA("domains"),
     "digitalcms.dev" -> SSA("flexible"),
+    "digitalcms.dev" -> SSA("flexible-secondary"),
     "digitalcms.dev" -> SSA("workflow"),
     "digitalcms.dev" -> SSA("cms-fronts"),
     "digitalcms.dev" -> SSA("elk-new"),
     "thegrid.dev" -> SSA("media-service"),
-    "commercial.dev" -> SSA(stack = "frontend", app = Some("ipad-ad-preview"))
-    //TODO: complete list
+    "commercial.dev" -> SSA(stack = "frontend", app = Some("ipad-ad-preview")),
+    "commercial.dev" -> SSA(stack = "flexible", app = Some("campaign-central")),
+    "content.platforms" -> SSA(stack = "content-api"),
+    "content.platforms" -> SSA(stack = "content-api-crier-v2"),
+    "content.platforms" -> SSA(stack = "content-api-crier-v2-preview"),
+    "content.platforms" -> SSA(stack = "content-api-dashboard"),
+    "content.platforms" -> SSA(stack = "content-api-facebook-news-bot"),
+    "content.platforms" -> SSA(stack = "content-api-logging"),
+    "content.platforms" -> SSA(stack = "content-api-okr-weekly"),
+    "content.platforms" -> SSA(stack = "content-api-preview"),
+    "content.platforms" -> SSA(stack = "content-api-recipeasy"),
+    "content.platforms" -> SSA(stack = "content-api-sanity-tests"),
+    "content.platforms" -> SSA(stack = "pubflow"),
+    "content.platforms" -> SSA(stack = "pubflow-preview"),
+    "mobile.server.side" -> SSA(stack = "mobile"),
+    "mobile.server.side" -> SSA(stack = "mobile-notifications"),
+    "mobile.server.side" -> SSA(stack = "mobile-prediction-io"),
+    "mobile.server.side" -> SSA(stack = "mobile-preview"),
+    "mobile.server.side" -> SSA(stack = "mobile-purchases"),
+    "mobile.server.side" -> SSA(stack = "recommendations"),
+    "mobile.server.side" -> SSA(stack = "recommendations-cluster"),
+    "infosec.ops" -> SSA(stack = "infosec-elk"),
+    "infosec.ops" -> SSA(stack = "infosec-elk-stack"),
+    "data.technology" -> SSA(stack = "ophan"),
+    "data.technology" -> SSA(stack = "ophan-data-lake"),
+    "data.technology" -> SSA(stack = "tailor"),
+    "membership-dev" -> SSA(stack = "membership"),
+    "membership-dev" -> SSA(stack = "subscriptions")
   )
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion in ThisBuild := "2.11.8"
 
 scalacOptions ++= Seq("-unchecked", "-optimise", "-deprecation",
   "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings",
-  "-Xfatal-warnings"
+  "-Xfatal-warnings", "-Ybackend:GenBCode"
 )
 
 scalacOptions in Test ++= Seq("-Yrangepos")


### PR DESCRIPTION
The AMIable weekly e-mails are working well so this fleshes out the ownership list so that it covers more of the known SSA combinations.

I also change the default recipient to be the tooling e-mail list so it's not just @philwills that is bombarded with them.