### PR TITLE
Remove `tailor`

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -67,7 +67,6 @@ object Owners extends Owners {
     "infosec.ops" -> SSA(stack = "infosec-elk-stack"),
     "data.technology" -> SSA(stack = "ophan"),
     "data.technology" -> SSA(stack = "ophan-data-lake"),
-    "data.technology" -> SSA(stack = "tailor"),
     "membership-dev" -> SSA(stack = "membership"),
     "membership-dev" -> SSA(stack = "subscriptions")
   )


### PR DESCRIPTION
We're removing all traces of `tailor` from our estate and have followed
this thread to: https://prism.gutools.co.uk/owners.