### PR TITLE
Update contact for Reader Revenue stacks

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -67,7 +67,8 @@ object Owners extends Owners {
     "infosec.ops" -> SSA(stack = "infosec-elk-stack"),
     "data.technology" -> SSA(stack = "ophan"),
     "data.technology" -> SSA(stack = "ophan-data-lake"),
-    "membership-dev" -> SSA(stack = "membership"),
-    "membership-dev" -> SSA(stack = "subscriptions")
+    "reader.revenue.dev" -> SSA(stack = "membership"),
+    "reader.revenue.dev" -> SSA(stack = "subscriptions"),
+    "reader.revenue.dev" -> SSA(stack = "support")
   )
 }


### PR DESCRIPTION
So that we receive notifications to the correct email address if we are running out of date AMIs.