### PR TITLE
Stack is now mandatory

### DIFF
--- a/app/collectors/data.scala
+++ b/app/collectors/data.scala
@@ -21,31 +21,21 @@ case class JsonDataCollector(origin:JsonOrigin, resource: ResourceType) extends 
 case class Data( key:String, values:Seq[Value]) extends IndexedItem {
   def arn: String = s"arn:gu:data:key/$key"
   def callFromArn: (String) => Call = arn => routes.Api.data(arn)
-  def firstMatchingData(stack:Option[String], app:String, stage:String): Option[Value] = {
-    stack.map { s =>
-      values.filter {
-        _.stack.isDefined
-      } find { data =>
-        data.appRegex.findFirstMatchIn(app).isDefined &&
-          data.stageRegex.findFirstMatchIn(stage).isDefined &&
-          data.stackRegex.get.findFirstMatchIn(s).isDefined
-      }
-    } getOrElse {
-      values.filter {
-        _.stack.isEmpty
-      } find {data =>
-        data.appRegex.findFirstMatchIn(app).isDefined && data.stageRegex.findFirstMatchIn(stage).isDefined
-      }
+  def firstMatchingData(stack:String, app:String, stage:String): Option[Value] = {
+    values.find { data =>
+      data.appRegex.findFirstMatchIn(app).isDefined &&
+        data.stageRegex.findFirstMatchIn(stage).isDefined &&
+        data.stackRegex.findFirstMatchIn(stack).isDefined
     }
   }
 }
 
-case class Value( stack: Option[String],
+case class Value( stack: String,
                   app: String,
                  stage: String,
                  value: String,
                  comment: Option[String] ) {
-  lazy val stackRegex = stack.map(s => s"^$s$$".r)
-  lazy val appRegex = ("^%s$" format app).r
-  lazy val stageRegex = ("^%s$" format stage).r
+  lazy val stackRegex = s"^$stack$$".r
+  lazy val appRegex = s"^$app$$".r
+  lazy val stageRegex = s"^$stage$$".r
 }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -250,15 +250,16 @@ trait Api extends Logging {
       val errors:Map[String,String] = Map.empty ++
           (if (app.isEmpty) Some("app" -> "Must specify app") else None) ++
           (if (stage.isEmpty) Some("stage" -> "Must specify stage") else None) ++
+          (if (stage.isEmpty) Some("stack" -> "Must specify stack") else None) ++
           (if (validKey.size == 0) Some("key" -> s"The key name $key was not found") else None) ++
           (if (validKey.size > 1) Some("key" -> s"The key name $key was matched multiple times") else None)
 
       if (!errors.isEmpty) throw ApiCallException(Json.toJson(errors).as[JsObject])
 
       val (label, data) = validKey.head
-      data.firstMatchingData(stack, app.get, stage.get).map(data => Map(label -> Seq(data))).getOrElse{
+      data.firstMatchingData(stack.get, app.get, stage.get).map(data => Map(label -> Seq(data))).getOrElse{
         throw ApiCallException(
-          Json.obj("value" -> s"Key $key has no matching value for stack=${stack.getOrElse("")}, app=$app and stage=$stage")
+          Json.obj("value" -> s"Key $key has no matching value for stack=$stack, app=$app and stage=$stage")
         )
       }
     } reduce { result =>


### PR DESCRIPTION
Stack in Riff-Raff is mandatory but Prism wasn't enforcing this with the data it used. This modifies it such that stack is mandatory in Prism too.

The underlying data has been modified to be correct.