### PR TITLE
Add Route53

### DIFF
--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -55,10 +55,10 @@ case class Label(resource:ResourceType, origin:Origin, itemCount:Int, createdAt:
   lazy val bestBefore = BestBefore(createdAt, resource.shelfLife, error = isError)
 }
 
-case class ResourceType( name: String, shelfLife: Duration )
+case class ResourceType( name: String, shelfLife: FiniteDuration, refreshPeriod: FiniteDuration )
 
-case class BestBefore(created:DateTime, shelfLife:Duration, error:Boolean) {
-  val bestBefore:DateTime = created plus shelfLife
+case class BestBefore(created:DateTime, shelfLife:FiniteDuration, error:Boolean) {
+  val bestBefore:DateTime = created plus Duration.millis(shelfLife.toMillis)
   def isStale:Boolean = error || (new DateTime() compareTo bestBefore) >= 0
   def age:Duration = new Duration(created, new DateTime)
 }

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -10,8 +10,11 @@ import utils.{Logging, PaginatedAWSRequest}
 
 import scala.collection.JavaConverters._
 import scala.util.Try
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
-object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acmCertificates", Duration.standardMinutes(15L))) {
+
+object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acmCertificates", 1 hour, 5 minutes)) {
   val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
     case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource)
   }

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -11,8 +11,11 @@ import utils.Logging
 import scala.collection.JavaConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
-object BucketCollectorSet extends CollectorSet[Bucket](ResourceType("bucket", Duration.standardMinutes(15L))) {
+
+object BucketCollectorSet extends CollectorSet[Bucket](ResourceType("bucket", 1 hour, 5 minutes)) {
   val lookupCollector: PartialFunction[Origin, Collector[Bucket]] = {
     case amazon: AmazonOrigin => AWSBucketCollector(amazon, resource)
   }

--- a/app/collectors/data.scala
+++ b/app/collectors/data.scala
@@ -6,7 +6,10 @@ import play.api.mvc.Call
 import controllers.routes
 import agent._
 
-object DataCollectorSet extends CollectorSet[Data](ResourceType("data", Duration.standardMinutes(15L))) {
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object DataCollectorSet extends CollectorSet[Data](ResourceType("data", 15 minutes, 1 minute)) {
   def lookupCollector: PartialFunction[Origin, Collector[Data]] = {
     case json:JsonOrigin => JsonDataCollector(json, resource)
   }

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -1,19 +1,19 @@
 package collectors
 
 import agent._
-import com.amazonaws.services.ec2.{AmazonEC2Client, AmazonEC2ClientBuilder}
-import com.amazonaws.services.ec2.model.{DescribeImagesRequest, Filter}
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
+import com.amazonaws.services.ec2.model.{DescribeImagesRequest, Filter, Image => AWSImage}
 import controllers.routes
-import org.joda.time.{DateTime, Duration}
+import org.joda.time.DateTime
 import play.api.mvc.Call
 import utils.Logging
 
-import collection.JavaConverters._
-import com.amazonaws.services.ec2.model.{Image => AWSImage}
-
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.Try
 
-object ImageCollectorSet extends CollectorSet[Image](ResourceType("images", Duration.standardMinutes(15L))) {
+object ImageCollectorSet extends CollectorSet[Image](ResourceType("images", 15 minutes, 1 minute)) {
   val lookupCollector: PartialFunction[Origin, Collector[Image]] = {
     case amazon:AmazonOrigin => AWSImageCollector(amazon, resource)
   }

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -15,8 +15,10 @@ import scala.language.postfixOps
 import com.amazonaws.services.ec2.{AmazonEC2Client, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Instance => AWSInstance, Reservation => AWSReservation}
 import agent._
+import scala.concurrent.duration._
 
-object InstanceCollectorSet extends CollectorSet[Instance](ResourceType("instance", Duration.standardMinutes(15L))) {
+
+object InstanceCollectorSet extends CollectorSet[Instance](ResourceType("instance", 15 minutes, 1 minute)) {
   val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
     case json:JsonOrigin => JsonInstanceCollector(json, resource)
     case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource)

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -3,7 +3,7 @@ package collectors
 import org.joda.time.{DateTime, Duration}
 
 import scala.collection.JavaConversions._
-import utils.Logging
+import utils.{Logging, PaginatedAWSRequest}
 import java.net.InetAddress
 
 import conf.PrismConfiguration.accounts
@@ -13,7 +13,7 @@ import controllers.routes
 
 import scala.language.postfixOps
 import com.amazonaws.services.ec2.{AmazonEC2Client, AmazonEC2ClientBuilder}
-import com.amazonaws.services.ec2.model.{Instance => AWSInstance, Reservation => AWSReservation}
+import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Instance => AWSInstance, Reservation => AWSReservation}
 import agent._
 
 object InstanceCollectorSet extends CollectorSet[Instance](ResourceType("instance", Duration.standardMinutes(15L))) {
@@ -41,7 +41,7 @@ case class AWSInstanceCollector(origin:AmazonOrigin, resource:ResourceType) exte
     .build()
 
   def getInstances:Iterable[(AWSReservation, AWSInstance)] = {
-    client.describeInstances().getReservations.flatMap(r => r.getInstances.map(r -> _))
+    PaginatedAWSRequest.run(client.describeInstances)(new DescribeInstancesRequest())
   }
 
   def crawl:Iterable[Instance] = {

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -12,7 +12,10 @@ import com.amazonaws.services.autoscaling.model.{DescribeLaunchConfigurationsReq
 
 import scala.util.Try
 
-object LaunchConfigurationCollectorSet extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations", Duration.standardMinutes(15L))) {
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object LaunchConfigurationCollectorSet extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations", 1 hour, 5 minutes)) {
   val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
     case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource)
   }

--- a/app/collectors/loadBalancers.scala
+++ b/app/collectors/loadBalancers.scala
@@ -1,0 +1,54 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder
+import com.amazonaws.services.elasticloadbalancing.model.{DescribeLoadBalancersRequest, LoadBalancerDescription}
+import controllers.routes
+import org.joda.time.Duration
+import play.api.mvc.Call
+import utils.{Logging, PaginatedAWSRequest}
+import scala.collection.JavaConverters._
+
+object LoadBalancerCollectorSet extends CollectorSet[LoadBalancer](ResourceType("loadBalancers", Duration.standardMinutes(15L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[LoadBalancer]] = {
+    case amazon: AmazonOrigin => LoadBalancerCollector(amazon, resource)
+  }
+}
+
+case class LoadBalancerCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[LoadBalancer] with Logging {
+
+  val client = AmazonElasticLoadBalancingClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
+
+  def crawl: Iterable[LoadBalancer] = PaginatedAWSRequest.run(client.describeLoadBalancers)(new DescribeLoadBalancersRequest()).map{ elb =>
+    LoadBalancer.fromApiData(elb, origin)
+  }
+}
+
+object LoadBalancer {
+  def fromApiData(loadBalancer: LoadBalancerDescription, origin: AmazonOrigin) = {
+    LoadBalancer(
+      arn = s"arn:aws:elasticloadbalancing:${origin.region}:${origin.accountNumber.getOrElse("")}:loadbalancer/${loadBalancer.getLoadBalancerName}",
+      name = loadBalancer.getLoadBalancerName,
+      dnsName = loadBalancer.getDNSName,
+      vpcId = Option(loadBalancer.getVPCId),
+      scheme = Option(loadBalancer.getScheme),
+      availabilityZones = loadBalancer.getAvailabilityZones.asScala.toList,
+      subnets = loadBalancer.getSubnets.asScala.toList
+    )
+  }
+}
+
+case class LoadBalancer(
+                        arn: String,
+                        name: String,
+                        dnsName: String,
+                        vpcId: Option[String],
+                        scheme: Option[String],
+                        availabilityZones: List[String],
+                        subnets: List[String]
+                      ) extends IndexedItem {
+  def callFromArn: (String) => Call = arn => routes.Api.elb(arn)
+}

--- a/app/collectors/loadBalancers.scala
+++ b/app/collectors/loadBalancers.scala
@@ -4,12 +4,14 @@ import agent._
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeLoadBalancersRequest, LoadBalancerDescription}
 import controllers.routes
-import org.joda.time.Duration
 import play.api.mvc.Call
 import utils.{Logging, PaginatedAWSRequest}
-import scala.collection.JavaConverters._
 
-object LoadBalancerCollectorSet extends CollectorSet[LoadBalancer](ResourceType("loadBalancers", Duration.standardMinutes(15L))) {
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object LoadBalancerCollectorSet extends CollectorSet[LoadBalancer](ResourceType("loadBalancers", 1 hour, 5 minutes)) {
   val lookupCollector: PartialFunction[Origin, Collector[LoadBalancer]] = {
     case amazon: AmazonOrigin => LoadBalancerCollector(amazon, resource)
   }

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -11,7 +11,10 @@ import utils.Logging
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("reservation", Duration.standardMinutes(15L))) {
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object ReservationCollectorSet extends CollectorSet[Reservation](ResourceType("reservation", 15 minutes, 1 minute)) {
   val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
     case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource)
   }

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -4,13 +4,14 @@ import agent._
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.{DescribeSecurityGroupsRequest, IpPermission, SecurityGroup => AWSSecurityGroup}
 import controllers.{routes, Prism}
-import org.joda.time.Duration
 import play.api.mvc.Call
 import utils.PaginatedAWSRequest
 
 import scala.collection.JavaConversions._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
-object SecurityGroupCollectorSet extends CollectorSet[SecurityGroup](ResourceType("security-group", Duration.standardMinutes(15L))) {
+object SecurityGroupCollectorSet extends CollectorSet[SecurityGroup](ResourceType("security-group", 1 hour, 5 minutes)) {
   def lookupCollector: PartialFunction[Origin, Collector[SecurityGroup]] = {
     case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource)
   }

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -2,10 +2,11 @@ package collectors
 
 import agent._
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
-import com.amazonaws.services.ec2.model.{IpPermission, SecurityGroup => AWSSecurityGroup}
+import com.amazonaws.services.ec2.model.{DescribeSecurityGroupsRequest, IpPermission, SecurityGroup => AWSSecurityGroup}
 import controllers.{routes, Prism}
 import org.joda.time.Duration
 import play.api.mvc.Call
+import utils.PaginatedAWSRequest
 
 import scala.collection.JavaConversions._
 
@@ -54,7 +55,7 @@ case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType)
   def crawl: Iterable[SecurityGroup] = {
     // get all existing groups to allow for cross referencing
     val existingGroups = Prism.securityGroupAgent.get().flatMap(_.data).map(sg => sg.groupId -> sg).toMap
-    val secGroups = client.describeSecurityGroups.getSecurityGroups
+    val secGroups = PaginatedAWSRequest.run(client.describeSecurityGroups)(new DescribeSecurityGroupsRequest())
     secGroups.map ( fromAWS(_, existingGroups) )
   }
 }

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -10,8 +10,10 @@ import utils.{Logging, PaginatedAWSRequest}
 
 import scala.collection.JavaConverters._
 import scala.util.Try
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
-object ServerCertificateCollectorSet extends CollectorSet[ServerCertificate](ResourceType("server-certificates", Duration.standardMinutes(14L))) {
+object ServerCertificateCollectorSet extends CollectorSet[ServerCertificate](ResourceType("server-certificates", 1 hour, 5 minutes)) {
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
     case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource)
   }

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -2,11 +2,13 @@ package collectors
 
 import agent._
 import com.amazonaws.services.route53.AmazonRoute53ClientBuilder
-import com.amazonaws.services.route53.model.{HostedZone, ListHostedZonesRequest}
+import com.amazonaws.services.route53.model.{HostedZone, ListHostedZonesRequest, ListResourceRecordSetsRequest, ResourceRecordSet}
 import controllers.routes
 import org.joda.time.Duration
 import play.api.mvc.Call
 import utils.{Logging, PaginatedAWSRequest}
+
+import scala.collection.JavaConverters._
 
 object Route53ZoneCollectorSet extends CollectorSet[Route53Zone](ResourceType("route53Zones", Duration.standardMinutes(15L))) {
   val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
@@ -22,21 +24,43 @@ case class Route53ZoneCollector(origin: AmazonOrigin, resource: ResourceType) ex
     .build()
 
   def crawl: Iterable[Route53Zone] = PaginatedAWSRequest.run(client.listHostedZones)(new ListHostedZonesRequest()).map{ zone =>
-    Route53Zone.fromApiData(zone, origin)
+    val records = PaginatedAWSRequest.run(client.listResourceRecordSets)(new ListResourceRecordSetsRequest(zone.getId))
+    Route53Zone.fromApiData(zone, records, origin)
   }
 }
 
 object Route53Zone {
-  def fromApiData(zone: HostedZone, origin: AmazonOrigin) = Route53Zone(
-    arn = s"arn:aws:route53:::hostedzone/${zone.getId}",
-    name = zone.getName,
-    id = zone.getId,
-    callerReference = zone.getCallerReference,
-    comment = Option(zone.getConfig.getComment),
-    isPrivateZone = zone.getConfig.getPrivateZone,
-    resourceRecordSetCount = zone.getResourceRecordSetCount
-  )
+  def fromApiData(zone: HostedZone, awsRecordSets: Iterable[ResourceRecordSet], origin: AmazonOrigin) = {
+    val recordSets: List[Route53Record] = awsRecordSets.map { record =>
+      val alias = Option(record.getAliasTarget).map(at => Route53Alias(at.getDNSName, at.getHostedZoneId, at.getEvaluateTargetHealth))
+      val maybeTtl: Option[Long] = Option(record.getTTL).map(_.longValue)
+      val records = record.getResourceRecords.asScala.map(_.getValue).toList
+      Route53Record(
+        record.getName,
+        if (alias.nonEmpty) "ALIAS" else record.getType,
+        maybeTtl,
+        if (records.isEmpty) None else Some(records),
+        alias
+      )
+    }.toList
+    val nameServers = recordSets.filter(rs => rs.name == zone.getName && rs.recordType == "NS").flatMap(_.records.getOrElse(Nil))
+    Route53Zone(
+      arn = s"arn:aws:route53:::hostedzone/${zone.getId}",
+      name = zone.getName,
+      id = zone.getId,
+      callerReference = zone.getCallerReference,
+      comment = Option(zone.getConfig.getComment),
+      isPrivateZone = zone.getConfig.getPrivateZone,
+      resourceRecordSetCount = zone.getResourceRecordSetCount,
+      nameServers = nameServers,
+      records = recordSets
+    )
+  }
 }
+
+case class Route53Alias(dnsName: String, hostedZoneId: String, evaluateHealth: Boolean)
+
+case class Route53Record(name: String, recordType: String, ttl: Option[Long], records: Option[List[String]], aliasTarget: Option[Route53Alias])
 
 case class Route53Zone(
                            arn: String,
@@ -45,7 +69,9 @@ case class Route53Zone(
                            callerReference: String,
                            comment: Option[String],
                            isPrivateZone: Boolean,
-                           resourceRecordSetCount: Long
+                           resourceRecordSetCount: Long,
+                           nameServers: List[String],
+                           records: List[Route53Record]
                          ) extends IndexedItem {
   def callFromArn: (String) => Call = arn => routes.Api.route53Zone(arn)
 }

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -1,0 +1,51 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.route53.AmazonRoute53ClientBuilder
+import com.amazonaws.services.route53.model.{HostedZone, ListHostedZonesRequest}
+import controllers.routes
+import org.joda.time.Duration
+import play.api.mvc.Call
+import utils.{Logging, PaginatedAWSRequest}
+
+object Route53ZoneCollectorSet extends CollectorSet[Route53Zone](ResourceType("route53Zones", Duration.standardMinutes(15L))) {
+  val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
+    case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource)
+  }
+}
+
+case class Route53ZoneCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Route53Zone] with Logging {
+
+  val client = AmazonRoute53ClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
+
+  def crawl: Iterable[Route53Zone] = PaginatedAWSRequest.run(client.listHostedZones)(new ListHostedZonesRequest()).map{ zone =>
+    Route53Zone.fromApiData(zone, origin)
+  }
+}
+
+object Route53Zone {
+  def fromApiData(zone: HostedZone, origin: AmazonOrigin) = Route53Zone(
+    arn = s"arn:aws:route53:::hostedzone/${zone.getId}",
+    name = zone.getName,
+    id = zone.getId,
+    callerReference = zone.getCallerReference,
+    comment = Option(zone.getConfig.getComment),
+    isPrivateZone = zone.getConfig.getPrivateZone,
+    resourceRecordSetCount = zone.getResourceRecordSetCount
+  )
+}
+
+case class Route53Zone(
+                           arn: String,
+                           name: String,
+                           id: String,
+                           callerReference: String,
+                           comment: Option[String],
+                           isPrivateZone: Boolean,
+                           resourceRecordSetCount: Long
+                         ) extends IndexedItem {
+  def callFromArn: (String) => Call = arn => routes.Api.route53Zone(arn)
+}

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -4,13 +4,14 @@ import agent._
 import com.amazonaws.services.route53.AmazonRoute53ClientBuilder
 import com.amazonaws.services.route53.model.{HostedZone, ListHostedZonesRequest, ListResourceRecordSetsRequest, ResourceRecordSet}
 import controllers.routes
-import org.joda.time.Duration
 import play.api.mvc.Call
 import utils.{Logging, PaginatedAWSRequest}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
-object Route53ZoneCollectorSet extends CollectorSet[Route53Zone](ResourceType("route53Zones", Duration.standardMinutes(15L))) {
+object Route53ZoneCollectorSet extends CollectorSet[Route53Zone](ResourceType("route53Zones", 1 hour, 5 minutes)) {
   val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
     case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource)
   }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -205,6 +205,13 @@ trait Api extends Logging {
     singleItem(Prism.acmCertificateAgent, arn)
   }
 
+  def route53ZoneList = Action.async { implicit request =>
+    itemList(Prism.route53ZoneAgent, "route53Zones")
+  }
+  def route53Zone(arn:String) = Action.async { implicit request =>
+    singleItem(Prism.route53ZoneAgent, arn)
+  }
+
   def bucketList = Action.async { implicit request =>
     itemList(Prism.bucketAgent, "bucket")
   }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -212,6 +212,13 @@ trait Api extends Logging {
     singleItem(Prism.route53ZoneAgent, arn)
   }
 
+  def elbList = Action.async { implicit request =>
+    itemList(Prism.elbAgent, "elb")
+  }
+  def elb(arn:String) = Action.async { implicit request =>
+    singleItem(Prism.elbAgent, arn)
+  }
+
   def bucketList = Action.async { implicit request =>
     itemList(Prism.bucketAgent, "bucket")
   }

--- a/app/controllers/ApiResult.scala
+++ b/app/controllers/ApiResult.scala
@@ -13,6 +13,9 @@ import scala.util.Try
 import utils.{ResourceFilter, Logging}
 import jsonimplicits.joda._
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 // use this when the API call has illegal parameters
 case class ApiCallException(failure:JsObject, status:Int = Status.BAD_REQUEST)
   extends RuntimeException(failure.fields.map(f => s"${f._1}: ${f._2}").mkString("; "))
@@ -118,7 +121,7 @@ object ApiResult extends Logging {
 
   def noSource(block: => JsValue)(implicit request:RequestHeader): Future[Result] = {
     val sourceLabel:Label = Label(
-      ResourceType(noSourceContainer.name, org.joda.time.Duration.standardMinutes(15)),
+      ResourceType(noSourceContainer.name, 15 minutes, 1 minute),
       new Origin {
         val account = "unknown"
         val vendor = "unknown"

--- a/app/controllers/OwnerApi.scala
+++ b/app/controllers/OwnerApi.scala
@@ -11,6 +11,9 @@ import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import utils.ResourceFilter
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 
 object OwnerApi extends Controller {
 
@@ -22,7 +25,7 @@ object OwnerApi extends Controller {
     }
   }
 
-  object OwnerResourceType extends ResourceType("Owners", Duration.standardDays(30))
+  object OwnerResourceType extends ResourceType("Owners", 30 days, 30 days)
 
   val ownerLabel = Label(
     OwnerResourceType,

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -5,17 +5,17 @@ import collectors._
 
 object Prism {
   val lazyStartup = conf.PrismConfiguration.accounts.lazyStartup
-  val instanceAgent = new CollectorAgent[Instance](InstanceCollectorSet.collectors, lazyStartup)
-  val dataAgent = new CollectorAgent[Data](DataCollectorSet.collectors, lazyStartup)
-  val securityGroupAgent = new CollectorAgent[SecurityGroup](SecurityGroupCollectorSet.collectors, lazyStartup)
-  val imageAgent = new CollectorAgent[Image](ImageCollectorSet.collectors, lazyStartup)
-  val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet.collectors, lazyStartup)
-  val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet.collectors, lazyStartup)
-  val acmCertificateAgent = new CollectorAgent[AcmCertificate](AmazonCertificateCollectorSet.collectors, lazyStartup)
-  val route53ZoneAgent = new CollectorAgent[Route53Zone](Route53ZoneCollectorSet.collectors, lazyStartup)
-  val elbAgent = new CollectorAgent[LoadBalancer](LoadBalancerCollectorSet.collectors, lazyStartup)
-  val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet.collectors, lazyStartup)
-  val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet.collectors, lazyStartup)
+  val instanceAgent = new CollectorAgent[Instance](InstanceCollectorSet, lazyStartup)
+  val dataAgent = new CollectorAgent[Data](DataCollectorSet, lazyStartup)
+  val securityGroupAgent = new CollectorAgent[SecurityGroup](SecurityGroupCollectorSet, lazyStartup)
+  val imageAgent = new CollectorAgent[Image](ImageCollectorSet, lazyStartup)
+  val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet, lazyStartup)
+  val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet, lazyStartup)
+  val acmCertificateAgent = new CollectorAgent[AcmCertificate](AmazonCertificateCollectorSet, lazyStartup)
+  val route53ZoneAgent = new CollectorAgent[Route53Zone](Route53ZoneCollectorSet, lazyStartup)
+  val elbAgent = new CollectorAgent[LoadBalancer](LoadBalancerCollectorSet, lazyStartup)
+  val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet, lazyStartup)
+  val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet, lazyStartup)
   val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
     serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent)
 }

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -12,8 +12,9 @@ object Prism {
   val launchConfigurationAgent = new CollectorAgent[LaunchConfiguration](LaunchConfigurationCollectorSet.collectors, lazyStartup)
   val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet.collectors, lazyStartup)
   val acmCertificateAgent = new CollectorAgent[AcmCertificate](AmazonCertificateCollectorSet.collectors, lazyStartup)
+  val route53ZoneAgent = new CollectorAgent[Route53Zone](Route53ZoneCollectorSet.collectors, lazyStartup)
   val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet.collectors, lazyStartup)
   val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet.collectors, lazyStartup)
   val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
-    serverCertificateAgent, acmCertificateAgent, bucketAgent, reservationAgent)
+    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, bucketAgent, reservationAgent)
 }

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -13,8 +13,9 @@ object Prism {
   val serverCertificateAgent = new CollectorAgent[ServerCertificate](ServerCertificateCollectorSet.collectors, lazyStartup)
   val acmCertificateAgent = new CollectorAgent[AcmCertificate](AmazonCertificateCollectorSet.collectors, lazyStartup)
   val route53ZoneAgent = new CollectorAgent[Route53Zone](Route53ZoneCollectorSet.collectors, lazyStartup)
+  val elbAgent = new CollectorAgent[LoadBalancer](LoadBalancerCollectorSet.collectors, lazyStartup)
   val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet.collectors, lazyStartup)
   val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet.collectors, lazyStartup)
   val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
-    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, bucketAgent, reservationAgent)
+    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -57,6 +57,7 @@ object model {
   implicit val domainValidationWriter = Json.writes[DomainValidation]
   implicit val renewalInfoWriter = Json.writes[RenewalInfo]
   implicit val acmCertificateWriter = Json.writes[AcmCertificate]
+  implicit val route53ZoneWriter = Json.writes[Route53Zone]
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -57,6 +57,8 @@ object model {
   implicit val domainValidationWriter = Json.writes[DomainValidation]
   implicit val renewalInfoWriter = Json.writes[RenewalInfo]
   implicit val acmCertificateWriter = Json.writes[AcmCertificate]
+  implicit val route53AliasWriter = Json.writes[Route53Alias]
+  implicit val route53RecordWriter = Json.writes[Route53Record]
   implicit val route53ZoneWriter = Json.writes[Route53Zone]
 
   implicit val labelWriter:Writes[Label] = new Writes[Label] {

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -61,6 +61,8 @@ object model {
   implicit val route53RecordWriter = Json.writes[Route53Record]
   implicit val route53ZoneWriter = Json.writes[Route53Zone]
 
+  implicit val loadBalancerWriter = Json.writes[LoadBalancer]
+
   implicit val labelWriter:Writes[Label] = new Writes[Label] {
     def writes(l: Label): JsValue = {
       Json.obj(

--- a/app/utils/PaginatedAWSRequest.scala
+++ b/app/utils/PaginatedAWSRequest.scala
@@ -4,6 +4,7 @@ import com.amazonaws.{AmazonWebServiceRequest, AmazonWebServiceResult}
 import com.amazonaws.services.autoscaling.model.{DescribeLaunchConfigurationsRequest, DescribeLaunchConfigurationsResult, LaunchConfiguration}
 import com.amazonaws.services.certificatemanager.model.{CertificateSummary, ListCertificatesRequest, ListCertificatesResult}
 import com.amazonaws.services.ec2.model._
+import com.amazonaws.services.elasticloadbalancing.model.{DescribeLoadBalancersRequest, DescribeLoadBalancersResult, LoadBalancerDescription}
 import com.amazonaws.services.identitymanagement.model.{ListServerCertificatesRequest, ListServerCertificatesResult, ServerCertificateMetadata}
 import com.amazonaws.services.route53.model._
 
@@ -63,6 +64,8 @@ object Paging {
   implicit def describeAcmCertificates: Paging[ListCertificatesRequest, ListCertificatesResult, String, CertificateSummary] =
     Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getCertificateSummaryList.asScala)
 
+  implicit def describeLoadBalancers: Paging[DescribeLoadBalancersRequest, DescribeLoadBalancersResult, String, LoadBalancerDescription] =
+    Paging.instance(r => Option(r.getNextMarker), r => m => r.withMarker(m.orNull), r => r.getLoadBalancerDescriptions.asScala)
 }
 
 object PaginatedAWSRequest {

--- a/app/utils/PaginatedAWSRequest.scala
+++ b/app/utils/PaginatedAWSRequest.scala
@@ -1,0 +1,92 @@
+package utils
+
+import com.amazonaws.{AmazonWebServiceRequest, AmazonWebServiceResult}
+import com.amazonaws.services.autoscaling.model.{DescribeLaunchConfigurationsRequest, DescribeLaunchConfigurationsResult, LaunchConfiguration}
+import com.amazonaws.services.certificatemanager.model.{CertificateSummary, ListCertificatesRequest, ListCertificatesResult}
+import com.amazonaws.services.ec2.model._
+import com.amazonaws.services.identitymanagement.model.{ListServerCertificatesRequest, ListServerCertificatesResult, ServerCertificateMetadata}
+import com.amazonaws.services.route53.model._
+
+import scala.collection.JavaConverters._
+
+trait Paging[Request, Result, A, Item] {
+  def getPageMarker(result: Result): Option[A]
+  def withPageMarker(request: Request, marker: Option[A]): Request
+  def getItemsFromResult(result: Result): Iterable[Item]
+}
+
+object Paging {
+  def instance[Request, Result, A, Item](
+                                    get: Result => Option[A],
+                                    set: Request => Option[A] => Request,
+                                    resultItems: Result => Iterable[Item]
+                                  ): Paging[Request, Result, A, Item] = new Paging[Request, Result, A, Item] {
+    override def getPageMarker(result: Result): Option[A] = get(result)
+    override def withPageMarker(request: Request, marker: Option[A]): Request =
+      set(request)(marker)
+    override def getItemsFromResult(result: Result): Iterable[Item] = resultItems(result)
+  }
+
+  implicit def listZonesMarking: Paging[ListHostedZonesRequest, ListHostedZonesResult, String, HostedZone] =
+    Paging.instance(r => Option(r.getMarker), r => m => r.withMarker(m.orNull), r => r.getHostedZones.asScala)
+
+  case class ListResourceRecordSetMarker(recordName: String, recordType: String, recordIdentifier: String)
+
+  implicit def listResourceRecordSets: Paging[ListResourceRecordSetsRequest, ListResourceRecordSetsResult, ListResourceRecordSetMarker, ResourceRecordSet] = {
+    val resultToMaybeMarker: ListResourceRecordSetsResult => Option[ListResourceRecordSetMarker] = result => {
+      if (result.isTruncated) {
+        Some(ListResourceRecordSetMarker(result.getNextRecordName, result.getNextRecordType, result.getNextRecordIdentifier))
+      } else {
+        None
+      }
+    }
+    Paging.instance(resultToMaybeMarker, request => marker => {
+      request
+        .withStartRecordName(marker.map(_.recordName).orNull)
+        .withStartRecordType(marker.map(_.recordType).orNull)
+        .withStartRecordIdentifier(marker.map(_.recordIdentifier).orNull)
+    }, r => r.getResourceRecordSets.asScala.toList)
+  }
+
+  implicit def describeInstances: Paging[DescribeInstancesRequest, DescribeInstancesResult, String, (Reservation, Instance)] =
+    Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getReservations.asScala.flatMap(r => r.getInstances.asScala.map(r -> _)))
+
+  implicit def describeLaunchConfigs: Paging[DescribeLaunchConfigurationsRequest, DescribeLaunchConfigurationsResult, String, LaunchConfiguration] =
+    Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getLaunchConfigurations.asScala)
+
+  implicit def describeSecurityGroups: Paging[DescribeSecurityGroupsRequest, DescribeSecurityGroupsResult, String, SecurityGroup] =
+    Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getSecurityGroups.asScala)
+
+  implicit def describeServerCertificates: Paging[ListServerCertificatesRequest, ListServerCertificatesResult, String, ServerCertificateMetadata] =
+    Paging.instance(r => Option(r.getMarker), r => m => r.withMarker(m.orNull), r => r.getServerCertificateMetadataList.asScala)
+
+  implicit def describeAcmCertificates: Paging[ListCertificatesRequest, ListCertificatesResult, String, CertificateSummary] =
+    Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getCertificateSummaryList.asScala)
+
+}
+
+object PaginatedAWSRequest {
+
+  def run[Request <: AmazonWebServiceRequest, Result <: AmazonWebServiceResult[_], Item, A]
+  (awsCall: Request => Result)(request: Request)
+  (implicit marking: Paging[Request, Result, A, Item]): Iterable[Item] = {
+
+    def recurse( request: Request,
+                 results: List[Item],
+                 timesThrottled: Int ): Iterable[Item] = {
+      val result = awsCall(request)
+      val newResults = results ++ marking.getItemsFromResult(result)
+      val marker = marking.getPageMarker(result)
+
+      marker match {
+        case None | Some("") =>
+          newResults
+
+        case otherMarker =>
+          recurse(marking.withPageMarker(request, otherMarker), newResults, timesThrottled)
+      }
+    }
+
+    recurse(request, List.empty, 0)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-acm" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-route53" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
 
     "com.gu" %% "management-play" % "8.0",
     "com.typesafe.akka" %% "akka-agent" % "2.4.1",

--- a/build.sbt
+++ b/build.sbt
@@ -14,11 +14,11 @@ scalacOptions ++= Seq("-unchecked", "-optimise", "-deprecation",
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 resolvers ++= Seq(
-  "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
-  "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-releases"
+  "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
+  "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "1.11.150"
+val awsVersion = "1.11.425"
 
 libraryDependencies ++= Seq(
     "com.google.code.findbugs" % "jsr305" % "2.0.0",
@@ -29,6 +29,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-acm" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-route53" % awsVersion,
 
     "com.gu" %% "management-play" % "8.0",
     "com.typesafe.akka" %% "akka-agent" % "2.4.1",

--- a/conf/routes
+++ b/conf/routes
@@ -40,6 +40,9 @@ GET        /acm-certificates/:arn             controllers.Api.acmCertificate(arn
 GET        /route53-zones                     controllers.Api.route53ZoneList
 GET        /route53-zones/:arn                controllers.Api.route53Zone(arn)
 
+GET        /elbs                              controllers.Api.elbList
+GET        /elbs/:arn                         controllers.Api.elb(arn)
+
 GET        /buckets                           controllers.Api.bucketList
 GET        /buckets/:arn                      controllers.Api.bucket(arn)
 

--- a/conf/routes
+++ b/conf/routes
@@ -37,6 +37,9 @@ GET        /server-certificates/:arn          controllers.Api.serverCertificate(
 GET        /acm-certificates                  controllers.Api.acmCertificateList
 GET        /acm-certificates/:arn             controllers.Api.acmCertificate(arn)
 
+GET        /route53-zones                     controllers.Api.route53ZoneList
+GET        /route53-zones/:arn                controllers.Api.route53Zone(arn)
+
 GET        /buckets                           controllers.Api.bucketList
 GET        /buckets/:arn                      controllers.Api.bucket(arn)
 

--- a/test/CollectorModelSpec.scala
+++ b/test/CollectorModelSpec.scala
@@ -1,21 +1,23 @@
 import agent.BestBefore
-import org.joda.time.{Duration, DateTime}
+import org.joda.time.DateTime
 import org.specs2.mutable._
+
+import scala.concurrent.duration._
 
 class CollectorModelSpec extends Specification {
   "BestBefore" should {
     "correctly calculate the best before date" in {
-      val bb = BestBefore(new DateTime(2013,11,8,10,0,0), Duration.standardSeconds(30), false)
+      val bb = BestBefore(new DateTime(2013,11,8,10,0,0), 30 seconds, false)
       bb.bestBefore should equalTo(new DateTime(2013,11,8,10,0,30))
     }
     "say it is stale if past best before" in {
-      val bb = BestBefore(new DateTime(2013,11,8,10,0,0), Duration.standardSeconds(30), false)
+      val bb = BestBefore(new DateTime(2013,11,8,10,0,0), 30 seconds, false)
       bb.bestBefore should be equalTo new DateTime(2013,11,8,10,0,30)
       (new DateTime).getMillis should be greaterThan bb.bestBefore.getMillis
       bb.isStale should beTrue
     }
     "say it is not stale if only just created" in {
-      val bb = BestBefore(new DateTime, Duration.standardSeconds(30), false)
+      val bb = BestBefore(new DateTime, 30 seconds, false)
       bb.isStale should beFalse
     }
   }


### PR DESCRIPTION
This adds crawling of Route53 hosted zones (including records) and also elastic load balancers.

As part of this the AWS libraries are bumped and a paginator is introduced. Note that instances were not previously paged in Prism and so some instances may not have been correctly crawled in the past (although there is scant evidence that any account was impacted by this). This fixes that.

TODO
------
 - [x] Update the IAM permissions for the prism roles (guardian/deploy-tools-platform#136) and (guardian/deploy-tools-platform#137)