### PR TITLE
Remove non-existent ELK stack from owners

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -36,7 +36,6 @@ object Owners extends Owners {
     "dotcom.platform" -> SSA(stack = "discussion"),
     "dotcom.platform" -> SSA(stack = "abacus"),
     "identitydev" -> SSA(stack = "identity"),
-    "identitydev" -> SSA(stack = "identity-elk"),
     "dig.dev.tooling" -> SSA("deploy"),
     "dig.dev.tooling" -> SSA("domains"),
     "digitalcms.dev" -> SSA("flexible"),


### PR DESCRIPTION
We no longer have any resources with this stack (I've double checked), so removing it.