### PR TITLE
Bump sbt version and aws sdk.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "1.11.425"
+val awsVersion = "1.11.518"
 
 libraryDependencies ++= Seq(
     "com.google.code.findbugs" % "jsr305" % "2.0.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.17

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,6 +14,6 @@ deployments:
       amiParameter: MachineImageAMI
       amiEncrypted: true
       amiTags:
-        Recipe: xenial-java8-deploy-infrastructure
+        Recipe: bionic-java8-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo


### PR DESCRIPTION
We're currently using an insecure version of the AWS SDK, and a rather old version of sbt. This PR should hopefully solve that.