### PR TITLE
Digital investigations owns pfi stacks

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -43,6 +43,8 @@ object Owners extends Owners {
     "digitalcms.dev" -> SSA("workflow"),
     "digitalcms.dev" -> SSA("cms-fronts"),
     "digitalcms.dev" -> SSA("elk-new"),
+    "digital.investigations" -> SSA("pfi-giant"),
+    "digital.investigations" -> SSA("pfi-playground"),
     "thegrid.dev" -> SSA("media-service"),
     "commercial.dev" -> SSA(stack = "frontend", app = Some("ipad-ad-preview")),
     "commercial.dev" -> SSA(stack = "flexible", app = Some("campaign-central")),


### PR DESCRIPTION
pfi-giant and pfi-playground did not have any owners, this pr adds the digital investigations as the owners.