### PR TITLE
MG - migrate to play 2.5 (continuation of #70 by mchv)

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,11 +1,9 @@
 import collection.mutable
-import conf.PlayRequestMetrics
 import controllers.PrismAgents
-import play.api.mvc.WithFilters
 import utils.{Logging, Lifecycle, ScheduledAgent}
 import play.api.Application
 
-object Global extends WithFilters(new GzipFilter() :: new JsonpFilter() :: PlayRequestMetrics.asFilters : _*) with Logging {
+object Global extends Logging {
 
   val lifecycleSingletons = mutable.Buffer[Lifecycle]()
 

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -3,7 +3,7 @@ import controllers.PrismAgents
 import utils.{Logging, Lifecycle, ScheduledAgent}
 import play.api.Application
 
-object Global extends Logging {
+object AgentsLifecycle extends Logging {
 
   val lifecycleSingletons = mutable.Buffer[Lifecycle]()
 

--- a/app/PrismApplicationLoader.scala
+++ b/app/PrismApplicationLoader.scala
@@ -65,7 +65,6 @@ class PrismComponents(context: Context)
 
   lazy val prismAgents = new controllers.PrismAgents(actorSystem, prismConfig)
 
-//  lazy val appController = new controllers.Application(router, configuration)
   lazy val appController = new controllers.Application(configuration)
   lazy val apiController = new controllers.Api(prismConfig, prismAgents)
   lazy val ownerApiController = new controllers.OwnerApi()

--- a/app/PrismApplicationLoader.scala
+++ b/app/PrismApplicationLoader.scala
@@ -6,6 +6,7 @@ import play.api.{ApplicationLoader, BuiltInComponentsFromContext}
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSClient
+import play.api.routing.Router
 import play.api.{Configuration, Mode}
 import play.filters.gzip.GzipFilterComponents
 
@@ -65,12 +66,12 @@ class PrismComponents(context: Context)
 
   lazy val prismAgents = new controllers.PrismAgents(actorSystem, prismConfig)
 
-  lazy val appController = new controllers.Application(configuration)
+  lazy val appController = new controllers.Application(configuration, router)
   lazy val apiController = new controllers.Api(prismConfig, prismAgents)
   lazy val ownerApiController = new controllers.OwnerApi()
   lazy val assets = new controllers.Assets(httpErrorHandler)
 
-  lazy val router = new Routes(httpErrorHandler, appController, apiController, assets, ownerApiController)
+  lazy val router: Router = new Routes(httpErrorHandler, appController, apiController, assets, ownerApiController)
 
   val jsonpFilter = new JsonpFilter()
   val metricsFilters = prismAgents.globalCollectorAgent.metrics.PlayRequestMetrics.asFilters // FIXME: Is this necessary? Why not just use cloudwatch instead of gu.management?

--- a/app/PrismApplicationLoader.scala
+++ b/app/PrismApplicationLoader.scala
@@ -70,7 +70,7 @@ class PrismComponents(context: Context)
   lazy val ownerApiController = new controllers.OwnerApi()
   lazy val assets = new controllers.Assets(httpErrorHandler)
 
-  lazy val router: Routes = new Routes(httpErrorHandler, appController, apiController, assets, ownerApiController)
+  lazy val router = new Routes(httpErrorHandler, appController, apiController, assets, ownerApiController)
 
   val jsonpFilter = new JsonpFilter()
   val metricsFilters = prismAgents.globalCollectorAgent.metrics.PlayRequestMetrics.asFilters // FIXME: Is this necessary? Why not just use cloudwatch instead of gu.management?

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -85,5 +85,6 @@ trait JsonCollectorTranslator[F,T] extends Collector[T] with Logging {
 
 trait GoogleDocCollector[T] extends Collector[T] {
   def origin:GoogleDocOrigin
-  def csvData:List[List[String]] = Await.result(GoogleDoc.getCsvForDoc(origin.docUrl), 1 minute)
+  // FIXME: This seems to be dead code. If it is not dead, then it will need to be refactored to take WsClient
+  // def csvData:List[List[String]] = Await.result(GoogleDoc.getCsvForDoc(origin.docUrl), 1 minute)
 }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -13,6 +13,8 @@ import jsonimplicits.RequestWrites
 
 class Api(prismConfig: conf.PrismConfiguration, prism: PrismAgents) extends Controller with Logging {
 
+  implicit val arnLookup = SecurityGroup.arnLookup(prism)
+
   implicit def referenceWrites[T <: IndexedItem](implicit arnLookup:ArnLookup[T], tWrites:Writes[T], request: RequestHeader): Writes[Reference[T]] = new Writes[Reference[T]] {
     def writes(o: Reference[T]) = {
       request.getQueryString("_reference") match {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -4,9 +4,12 @@ import play.api.Configuration
 import play.api.mvc._
 import router.Routes
 
-class Application(routes: Routes, configuration: Configuration) extends Controller {
+//class Application(routes: Routes, configuration: Configuration) extends Controller {
+class Application(configuration: Configuration) extends Controller {
   def index = Action {
-    Ok(views.html.index(routes.documentation))
+    // FIXME: How to inject routes at compile time to get at routes.documentation?
+//    Ok(views.html.index(routes.documentation))
+    Ok("woohoo")
   }
 
   def config = Action {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -4,6 +4,7 @@ import play.api.Configuration
 import play.api.mvc._
 import play.api.routing.Router
 
+// router parameter is by-name because otherwise StackOverflowError is thrown due to initialisation order problem in ApplicationLoader
 class Application(configuration: Configuration, router: => Router) extends Controller {
   def index = Action {
     Ok(views.html.index(router.documentation))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,14 +2,12 @@ package controllers
 
 import play.api.Configuration
 import play.api.mvc._
-import router.Routes
 
-//class Application(routes: Routes, configuration: Configuration) extends Controller {
 class Application(configuration: Configuration) extends Controller {
   def index = Action {
     // FIXME: How to inject routes at compile time to get at routes.documentation?
-//    Ok(views.html.index(routes.documentation))
-    Ok("woohoo")
+    // Ok(views.html.index(routes.documentation))
+    Ok("ok")
   }
 
   def config = Action {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,17 +1,15 @@
 package controllers
 
+import play.api.Configuration
 import play.api.mvc._
-import play.api.Play
+import router.Routes
 
-class Application extends Controller {
-
+class Application(routes: Routes, configuration: Configuration) extends Controller {
   def index = Action {
-    import play.api.Play.current
-    Ok(views.html.index(Play.routes.documentation))
+    Ok(views.html.index(routes.documentation))
   }
 
   def config = Action {
-    Ok(play.api.Play.current.configuration.underlying.root().render())
+    Ok(configuration.underlying.root().render())
   }
-
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,12 +2,11 @@ package controllers
 
 import play.api.Configuration
 import play.api.mvc._
+import play.api.routing.Router
 
-class Application(configuration: Configuration) extends Controller {
+class Application(configuration: Configuration, router: => Router) extends Controller {
   def index = Action {
-    // FIXME: How to inject routes at compile time to get at routes.documentation?
-    // Ok(views.html.index(routes.documentation))
-    Ok("ok")
+    Ok(views.html.index(router.documentation))
   }
 
   def config = Action {

--- a/app/utils/googleDocs.scala
+++ b/app/utils/googleDocs.scala
@@ -1,14 +1,13 @@
 package utils
 
 import scala.util.parsing.combinator._
-import java.net.{URLDecoder, URL}
-import play.api.libs.ws.WS
+import java.net.URL
+import play.api.libs.ws.WSClient
 import play.api.http.Status._
 import play.api.http.HeaderNames
 import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.concurrent.ExecutionContext.Implicits.global
-import play.api.Play.current
 
 // A CSV parser based on RFC4180
 // http://tools.ietf.org/html/rfc4180
@@ -44,7 +43,7 @@ object CSV extends RegexParsers {
   }
 }
 
-object GoogleDoc extends Logging {
+class GoogleDoc(wsClient: WSClient) extends Logging {
   def getCsvForDoc(docUrl:URL): Future[List[List[String]]] = {
     getUrlData(docUrl).map(CSV.parse)
   }
@@ -55,7 +54,7 @@ object GoogleDoc extends Logging {
     val headers:Seq[(String,String)] = if (cookies.isEmpty) Seq.empty else {
       Seq(HeaderNames.COOKIE -> cookies.map{case (name, value) => s"$name=$value"}.mkString("; "))
     }
-    WS.url(url.toString)
+    wsClient.url(url.toString)
       .withFollowRedirects(false)
       .withHeaders(headers:_*)
       .get().flatMap { response =>

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-acm" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-route53" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
-
+    ws,
     "com.gu" %% "management-play" % "8.0",
     "com.typesafe.akka" %% "akka-agent" % "2.4.1",
     "com.typesafe.akka" %% "akka-slf4j" % "2.4.1",

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -56,12 +56,13 @@ object ApiSpec extends PlaySpecification with Results {
     }
   }
 
-  class TestApi() extends Controller with Api
+  class TestApi() extends Controller
 
   "Application" should {
     "return a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
-      val api = new TestApi()
-      val result = api.instanceList(FakeRequest())
+//      val api = new TestApi()
+//      val result = api.instanceList(FakeRequest())
+      val result = route(app, FakeRequest(GET, "/instances")).get
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
@@ -72,28 +73,29 @@ object ApiSpec extends PlaySpecification with Results {
 
     "filter a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
       val api = new TestApi()
-      val result = api.instanceList(FakeRequest(GET, "/instances?vendor=aws"))
+//      val result = api.instanceList(FakeRequest(GET, "/instances?vendor=aws"))
+      val result = route(app, (FakeRequest(GET, "/instances?vendor=aws"))).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 8
     }
 
     "invert filter a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
       val api = new TestApi()
-      val result = api.instanceList(FakeRequest(GET, "/instances?vendor!=aws"))
+      val result = route(app, FakeRequest(GET, "/instances?vendor!=aws")).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 7
     }
 
     "filter a list of instances using a regex" in new WithApplicationLoader(new PrismApplicationLoader()) {
       val api = new TestApi()
-      val result = api.instanceList(FakeRequest(GET, "/instances?mainclasses~=.*db.*"))
+      val result = route(app, FakeRequest(GET, "/instances?mainclasses~=.*db.*")).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 6
     }
 
     "filter a list of instances by nested field" in new WithApplicationLoader(new PrismApplicationLoader()) {
       val api = new TestApi()
-      val result = api.instanceList(FakeRequest(GET, "/instances?tags.App=db"))
+      val result = route(app, (FakeRequest(GET, "/instances?tags.App=db"))).get
       //contentAsString(result) mustEqual("")
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 3

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -56,7 +56,6 @@ object ApiSpec extends PlaySpecification with Results {
     }
   }
 
-  class TestApi() extends Controller
 
   "Application" should {
     "return a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
@@ -70,28 +69,24 @@ object ApiSpec extends PlaySpecification with Results {
     }
 
     "filter a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
-      val api = new TestApi()
       val result = route(app, (FakeRequest(GET, "/instances?vendor=aws"))).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 8
     }
 
     "invert filter a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
-      val api = new TestApi()
       val result = route(app, FakeRequest(GET, "/instances?vendor!=aws")).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 7
     }
 
     "filter a list of instances using a regex" in new WithApplicationLoader(new PrismApplicationLoader()) {
-      val api = new TestApi()
       val result = route(app, FakeRequest(GET, "/instances?mainclasses~=.*db.*")).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 6
     }
 
     "filter a list of instances by nested field" in new WithApplicationLoader(new PrismApplicationLoader()) {
-      val api = new TestApi()
       val result = route(app, (FakeRequest(GET, "/instances?tags.App=db"))).get
       //contentAsString(result) mustEqual("")
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -1,4 +1,4 @@
-import controllers.{Api, ApiCallException, ApiResult}
+import controllers.{ApiCallException, ApiResult}
 
 import play.api.libs.json._
 import play.api.libs.json.JsArray
@@ -60,8 +60,6 @@ object ApiSpec extends PlaySpecification with Results {
 
   "Application" should {
     "return a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
-//      val api = new TestApi()
-//      val result = api.instanceList(FakeRequest())
       val result = route(app, FakeRequest(GET, "/instances")).get
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
@@ -73,7 +71,6 @@ object ApiSpec extends PlaySpecification with Results {
 
     "filter a list of instances" in new WithApplicationLoader(new PrismApplicationLoader()) {
       val api = new TestApi()
-//      val result = api.instanceList(FakeRequest(GET, "/instances?vendor=aws"))
       val result = route(app, (FakeRequest(GET, "/instances?vendor=aws"))).get
       val jsonInstances = (contentAsJson(result) \ "data" \ "instances").get
       jsonInstances.as[JsArray].value.length mustEqual 8

--- a/test/OwnerApiSpec.scala
+++ b/test/OwnerApiSpec.scala
@@ -1,11 +1,9 @@
-import controllers.OwnerApi
 import play.api.mvc._
 import play.api.test._
 
 object OwnerApiSpec extends PlaySpecification with Results {
-  "Getting the owners for a stack should return a successful status when the parameters are set correctly - ie. the stack is defined" in {
-    implicit val request = FakeRequest(GET, "/owners/forStack/stackname")
-    val result = OwnerApi.ownerForStack("stackname")(request)
+  "Getting the owners for a stack should return a successful status when the parameters are set correctly - ie. the stack is defined" in new WithApplicationLoader(new PrismApplicationLoader()) {
+    val result = route(app, FakeRequest(GET, "/owners/forStack/stackname")).get
     contentType(result) must beSome("application/json")
     status(result) must equalTo(OK)
   }


### PR DESCRIPTION
Note this PR is to be merged into #70 by @mchv. 

It seems to work in CODE.

There are two FIXMEs:

- Are `gu.management` metrics necessary? Isn't cloudwatch sufficient? This PR disables them - see `httpFilters` definition.
- `GoogleDoc.getCsvForDoc` seems to be dead code.