### PR TITLE
gracefully handle AccessDeniedException for lambda indexing

### DIFF
--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -1,7 +1,7 @@
 package collectors
 
 import agent._
-import com.amazonaws.services.lambda.model.{FunctionConfiguration, ListFunctionsRequest, ListTagsRequest}
+import com.amazonaws.services.lambda.model.{AWSLambdaException, FunctionConfiguration, ListFunctionsRequest, ListTagsRequest}
 import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
 import controllers.routes
 import play.api.mvc.Call
@@ -24,7 +24,7 @@ case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType) exte
     .withRegion(origin.awsRegion)
     .build()
 
-  def crawl: Iterable[Lambda] = {
+  def crawl: Iterable[Lambda] = try {
     PaginatedAWSRequest.run(client.listFunctions)(new ListFunctionsRequest()).map { lambda => {
       val tags = client.listTags(new ListTagsRequest().withResource(lambda.getFunctionArn)).getTags.toMap
       Thread.sleep(100) // this avoids ThrottlingException back from AWS
@@ -35,8 +35,12 @@ case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType) exte
         tags
       )
     }
-
     }
+  }
+  catch {
+    case e: AWSLambdaException if e.getErrorCode == "AccessDeniedException" =>
+      log.warn(s"Could not get lambda information for ${origin.account}", e)
+      Nil
   }
 }
 


### PR DESCRIPTION
Follow on from https://github.com/guardian/prism/pull/71

Turns out there are a number of additional AWS accounts which the `PROD` instance of Prism indexes (but not `CODE`) which were not StackSet to include the new permissions `lambda:ListFunctions` and `lambda:ListTags`. Which causes `AccessDeniedException` when trying to index lambdas on those accounts. This PR addresses that by catching the `AccessDeniedException`, logging then returning `Nil`.