### PR TITLE
add lambda indexing

### DIFF
--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -30,7 +30,7 @@ class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], lazyStar
   
   def getLabels: Seq[Label] = get().map(_.label).toSeq
 
-  def size = get().map(_.data.size).fold(0)(_+_)
+  def size = get().map(_.data.size).sum
 
   def update(collector: Collector[T], previous:Datum[T]):Datum[T] = {
       val s = new StopWatch

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -17,6 +17,14 @@ trait IndexedItem {
   def fieldIndex: Map[String, String] = Map("arn" -> arn)
 }
 
+trait IndexedItemWithStage extends IndexedItem {
+  val stage: Option[String] = None
+}
+
+trait IndexedItemWithStack extends IndexedItem {
+  val stack: Option[String] = None
+}
+
 abstract class CollectorSet[T](val resource:ResourceType) extends Logging {
   def lookupCollector:PartialFunction[Origin, Collector[T]]
   def collectorFor(origin:Origin): Option[Collector[T]] = {

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -1,18 +1,17 @@
 package collectors
 
-import org.joda.time.{DateTime, Duration}
+import org.joda.time.DateTime
 
 import scala.collection.JavaConversions._
 import utils.{Logging, PaginatedAWSRequest}
 import java.net.InetAddress
 
-import conf.PrismConfiguration.accounts
 import play.api.libs.json.Json
 import play.api.mvc.Call
 import controllers.routes
 
 import scala.language.postfixOps
-import com.amazonaws.services.ec2.{AmazonEC2Client, AmazonEC2ClientBuilder}
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Instance => AWSInstance, Reservation => AWSReservation}
 import agent._
 import scala.concurrent.duration._
@@ -179,14 +178,14 @@ case class Instance(
                  vendor: String,
                  securityGroups: Seq[Reference[SecurityGroup]],
                  tags: Map[String, String] = Map.empty,
-                 stage: Option[String],
-                 stack: Option[String],
+                 override val stage: Option[String],
+                 override val stack: Option[String],
                  app: List[String],
                  mainclasses: List[String],
                  role: Option[String],
                  management:Option[Seq[ManagementEndpoint]],
                  specification:Option[InstanceSpecification]
-                ) extends IndexedItem {
+                ) extends IndexedItemWithStage with IndexedItemWithStack {
 
   def callFromArn: (String) => Call = arn => routes.Api.instance(arn)
   override lazy val fieldIndex: Map[String, String] = super.fieldIndex ++ Map("dnsName" -> dnsName) ++ stage.map("stage" ->)

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -1,0 +1,66 @@
+package collectors
+
+import agent._
+import com.amazonaws.services.lambda.model.{FunctionConfiguration, ListFunctionsRequest, ListTagsRequest}
+import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
+import controllers.routes
+import play.api.mvc.Call
+import utils.{Logging, PaginatedAWSRequest}
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object LambdaCollectorSet extends CollectorSet[Lambda](ResourceType("lambda", 1 hour, 5 minutes)) {
+  val lookupCollector: PartialFunction[Origin, Collector[Lambda]] = {
+    case amazon: AmazonOrigin => AWSLambdaCollector(amazon, resource)
+  }
+}
+
+case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Lambda] with Logging {
+
+  val client = AWSLambdaClientBuilder.standard()
+    .withCredentials(origin.credentials.provider)
+    .withRegion(origin.awsRegion)
+    .build()
+
+  def crawl: Iterable[Lambda] = {
+    PaginatedAWSRequest.run(client.listFunctions)(new ListFunctionsRequest()).map { lambda => {
+      val tags = client.listTags(new ListTagsRequest().withResource(lambda.getFunctionArn)).getTags.toMap
+      Thread.sleep(100) // this avoids ThrottlingException back from AWS
+      Lambda.fromApiData(
+        lambda,
+        client,
+        origin.region,
+        tags
+      )
+    }
+
+    }
+  }
+}
+
+object Lambda {
+
+  def fromApiData(lambda: FunctionConfiguration, client: AWSLambda, region: String, tags: Map[String, String]): Lambda = Lambda(
+    arn = lambda.getFunctionArn,
+    name = lambda.getFunctionName,
+    region,
+    runtime = lambda.getRuntime,
+    tags,
+    stage = tags.get("Stage"),
+    stack = tags.get("Stack")
+  )
+}
+
+case class Lambda(
+  arn: String,
+  name: String,
+  region: String,
+  runtime: String,
+  tags: Map[String, String],
+  override val stage: Option[String],
+  override val stack: Option[String]
+) extends IndexedItemWithStage with IndexedItemWithStack {
+  override def callFromArn: (String) => Call = arn => routes.Api.instance(arn)
+}

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -140,8 +140,8 @@ object SourceMetrics {
 object DataMetrics extends Logging {
   val resourceNames = Prism.allAgents.flatMap(_.resourceName).distinct
   def countResources(resource:String) = {
-    val filteredAgents = Prism.allAgents.filter{ _.resourceName == Some(resource) }
-    filteredAgents.map(_.size).fold(0)(_+_)
+    val filteredAgents = Prism.allAgents.filter{ _.resourceName.contains(resource) }
+    filteredAgents.map(_.size).sum
   }
   val resourceGauges = resourceNames.map { resource =>
     new GaugeMetric("prism", s"${resource}_entities", s"$resource entities", s"Number of $resource entities", () => countResources(resource))

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -6,6 +6,7 @@ import collectors._
 object Prism {
   val lazyStartup = conf.PrismConfiguration.accounts.lazyStartup
   val instanceAgent = new CollectorAgent[Instance](InstanceCollectorSet, lazyStartup)
+  val lambdaAgent = new CollectorAgent[Lambda](LambdaCollectorSet, lazyStartup)
   val dataAgent = new CollectorAgent[Data](DataCollectorSet, lazyStartup)
   val securityGroupAgent = new CollectorAgent[SecurityGroup](SecurityGroupCollectorSet, lazyStartup)
   val imageAgent = new CollectorAgent[Image](ImageCollectorSet, lazyStartup)
@@ -16,6 +17,6 @@ object Prism {
   val elbAgent = new CollectorAgent[LoadBalancer](LoadBalancerCollectorSet, lazyStartup)
   val bucketAgent = new CollectorAgent[Bucket](BucketCollectorSet, lazyStartup)
   val reservationAgent = new CollectorAgent[Reservation](ReservationCollectorSet, lazyStartup)
-  val allAgents = Seq(instanceAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
+  val allAgents = Seq(instanceAgent, lambdaAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
     serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -49,6 +49,7 @@ object model {
   implicit val launchConfigurationWriter = Json.writes[LaunchConfiguration]
   implicit val serverCertificateWriter = Json.writes[ServerCertificate]
   implicit val bucketWriter = Json.writes[Bucket]
+  implicit val lambdaWriter = Json.writes[Lambda]
   implicit val reservationWriter: Writes[Reservation] = {
     implicit val recurringCharge = Json.writes[RecurringCharge]
     Json.writes[Reservation]

--- a/app/utils/PaginatedAWSRequest.scala
+++ b/app/utils/PaginatedAWSRequest.scala
@@ -1,11 +1,13 @@
 package utils
 
+import collectors.Lambda
 import com.amazonaws.{AmazonWebServiceRequest, AmazonWebServiceResult}
 import com.amazonaws.services.autoscaling.model.{DescribeLaunchConfigurationsRequest, DescribeLaunchConfigurationsResult, LaunchConfiguration}
 import com.amazonaws.services.certificatemanager.model.{CertificateSummary, ListCertificatesRequest, ListCertificatesResult}
 import com.amazonaws.services.ec2.model._
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeLoadBalancersRequest, DescribeLoadBalancersResult, LoadBalancerDescription}
 import com.amazonaws.services.identitymanagement.model.{ListServerCertificatesRequest, ListServerCertificatesResult, ServerCertificateMetadata}
+import com.amazonaws.services.lambda.model.{FunctionConfiguration, ListFunctionsRequest, ListFunctionsResult}
 import com.amazonaws.services.route53.model._
 
 import scala.collection.JavaConverters._
@@ -51,6 +53,9 @@ object Paging {
 
   implicit def describeInstances: Paging[DescribeInstancesRequest, DescribeInstancesResult, String, (Reservation, Instance)] =
     Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getReservations.asScala.flatMap(r => r.getInstances.asScala.map(r -> _)))
+
+  implicit def describeLambdas: Paging[ListFunctionsRequest, ListFunctionsResult, String, FunctionConfiguration] =
+    Paging.instance(r => Option(r.getNextMarker), r => m => r.withMarker(m.orNull), r => r.getFunctions.asScala)
 
   implicit def describeLaunchConfigs: Paging[DescribeLaunchConfigurationsRequest, DescribeLaunchConfigurationsResult, String, LaunchConfiguration] =
     Paging.instance(r => Option(r.getNextToken), r => t => r.withNextToken(t.orNull), r => r.getLaunchConfigurations.asScala)

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ version := "1.0-SNAPSHOT"
 
 scalaVersion in ThisBuild := "2.11.8"
 
-scalacOptions ++= Seq("-unchecked", "-optimise", "-deprecation",
-  "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings",
-  "-Xfatal-warnings", "-Ybackend:GenBCode"
+scalacOptions ++= Seq("-unchecked", "-deprecation",
+  "-Xcheckinit", "-encoding", "utf8", "-feature",
+  "-Yinline-warnings", "-Xfatal-warnings"
 )
 
 scalacOptions in Test ++= Seq("-Yrangepos")
@@ -28,6 +28,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-acm" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-route53" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,

--- a/conf/routes
+++ b/conf/routes
@@ -22,6 +22,9 @@ GET        /instances/roles                   controllers.Api.roleList
 GET        /instances/mainclasses             controllers.Api.mainclassList
 GET        /instances/:arn                    controllers.Api.instance(arn)
 
+GET        /lambdas                           controllers.Api.lambdaList
+GET        /lambdas/:arn                      controllers.Api.lambda(arn)
+
 GET        /security-groups                   controllers.Api.securityGroupList
 GET        /security-groups/:arn              controllers.Api.securityGroup(arn)
 


### PR DESCRIPTION
_This is basically the revert of the revert of https://github.com/guardian/prism/pull/71 (revert was due to PrismRole IAM issues - which are now resolved thanks to @katebee)_
<hr/>

For example... 
![image](https://user-images.githubusercontent.com/19289579/70818815-947d6080-1dcc-11ea-8dd1-4e0330276adb.png)
![image](https://user-images.githubusercontent.com/19289579/70819082-38ffa280-1dcd-11ea-8040-101091a2d426.png)

... this particular one is filtered on `runtime`, which is a nice touch and will help with Node EOL upgrades.

Original motivation here was actually to ensure `Stage`s used for lambdas were available in RiffRaff - for example in RR we use `DEV` Stage for quite a number of API Gateway backed lambdas (for consistency with play apps where the `DEV` instance runs on our machines - which is much harder for API Gateway Lambdas).

## MUST add the following permissions to the `PrismRole` in all the AWS accounts

- `lambda:ListFunctions`
- `lambda:ListTags`

... see https://github.com/guardian/deploy-tools-platform/pull/181 (will be StackSet to all the AWS accounts).