### PR TITLE
Metadata endpoint

### DIFF
--- a/app/agent/Metadata.scala
+++ b/app/agent/Metadata.scala
@@ -2,21 +2,35 @@ package agent
 
 import controllers.Prism
 import org.joda.time.DateTime
-import scala.concurrent.duration._
+import utils.{CaseClassFieldList, Logging}
 
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
 case class Metadata(key: String, description: String, defaultFields: Seq[String], allFields: Seq[String])
 
-object Metadata {
+object Metadata extends Logging {
   val initTime = new DateTime()
+
+  def prependMetaOrigin(fields:List[String]): List[String] = fields.map(f => s"meta.origin.$f")
+
+  // this should really be automatically generated from all class names but
+  // that's a bit tricky without further reflection and life is too short
+  val originFieldsMap: Map[String, List[String]] = Map(
+    classOf[AmazonOrigin].getName -> CaseClassFieldList.allFields[AmazonOrigin],
+    classOf[JsonOrigin].getName -> CaseClassFieldList.allFields[JsonOrigin],
+    classOf[GoogleDocOrigin].getName -> CaseClassFieldList.allFields[GoogleDocOrigin]
+  ).mapValues(prependMetaOrigin)
 
   def metadata:Datum[Metadata] = {
     val typeList = Prism.allAgents.map { agent =>
       val key = agent.collectorSet.resource.name
       //val desc = agent.collectorSet.resource.description
       val defFields = agent.collectorSet.defaultFields
-      val allFields = agent.collectorSet.allFields
+      val typeFields = agent.collectorSet.allFields
+      val originTypes = agent.collectorSet.collectors.map(_.origin.getClass.getName).distinct
+      val originFields = originTypes.flatMap(originFieldsMap.getOrElse(_, Nil))
+      val allFields = typeFields ++ originFields
       Metadata(key, "", defFields, allFields)
     }
     val label = Label(

--- a/app/agent/Metadata.scala
+++ b/app/agent/Metadata.scala
@@ -1,0 +1,35 @@
+package agent
+
+import controllers.Prism
+import org.joda.time.DateTime
+import scala.concurrent.duration._
+
+import scala.language.postfixOps
+
+case class Metadata(key: String, description: String, defaultFields: Seq[String], allFields: Seq[String])
+
+object Metadata {
+  val initTime = new DateTime()
+
+  def metadata:Datum[Metadata] = {
+    val typeList = Prism.allAgents.map { agent =>
+      val key = agent.collectorSet.resource.name
+      //val desc = agent.collectorSet.resource.description
+      val defFields = agent.collectorSet.defaultFields
+      val allFields = agent.collectorSet.allFields
+      Metadata(key, "", defFields, allFields)
+    }
+    val label = Label(
+      ResourceType("metadata", 1 day, 1 day),
+      new Origin {
+        val vendor = "prism"
+        val account = "prism"
+        val resources = Set("metadata")
+        val jsonFields = Map.empty[String, String]
+      },
+      typeList.size,
+      initTime
+    )
+    Datum(label, typeList)
+  }
+}

--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -2,16 +2,19 @@ package agent
 
 import play.api.libs.concurrent.Akka
 import utils.{LifecycleWithoutApp, Logging, ScheduledAgent}
+
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import akka.agent.Agent
 import org.joda.time.DateTime
 import akka.actor.ActorSystem
 import play.api.Play.current
+
 import scala.concurrent.ExecutionContext
 import play.api.libs.json.Json.JsValueWrapper
 import conf.SourceMetrics
 import com.gu.management.StopWatch
+import controllers.Prism
 
 class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], lazyStartup:Boolean = true) extends Logging with LifecycleWithoutApp {
 

--- a/app/collectors/data.scala
+++ b/app/collectors/data.scala
@@ -9,11 +9,6 @@ import agent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-object DataCollectorSet extends CollectorSet[Data](ResourceType("data", 15 minutes, 1 minute)) {
-  def lookupCollector: PartialFunction[Origin, Collector[Data]] = {
-    case json:JsonOrigin => JsonDataCollector(json, resource)
-  }
-}
 
 case class JsonDataCollector(origin:JsonOrigin, resource: ResourceType) extends JsonCollector[Data] {
   implicit val valueReads = Json.reads[Value]
@@ -33,6 +28,12 @@ case class Data( key:String, values:Seq[Value]) extends IndexedItem {
   }
 }
 
+object Data {
+  implicit val fields = new Fields[Data] {
+    override def defaultFields: Seq[String] = Seq("key")
+  }
+}
+
 case class Value( stack: String,
                   app: String,
                  stage: String,
@@ -41,4 +42,10 @@ case class Value( stack: String,
   lazy val stackRegex = s"^$stack$$".r
   lazy val appRegex = s"^$app$$".r
   lazy val stageRegex = s"^$stage$$".r
+}
+
+object DataCollectorSet extends CollectorSet[Data](ResourceType("data", 15 minutes, 1 minute)) {
+  def lookupCollector: PartialFunction[Origin, Collector[Data]] = {
+    case json:JsonOrigin => JsonDataCollector(json, resource)
+  }
 }

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -16,14 +16,6 @@ import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Instance => A
 import agent._
 import scala.concurrent.duration._
 
-
-object InstanceCollectorSet extends CollectorSet[Instance](ResourceType("instance", 15 minutes, 1 minute)) {
-  val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
-    case json:JsonOrigin => JsonInstanceCollector(json, resource)
-    case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource)
-  }
-}
-
 case class JsonInstanceCollector(origin:JsonOrigin, resource:ResourceType) extends JsonCollector[Instance] {
   import jsonimplicits.joda.dateTimeReads
   import jsonimplicits.model._
@@ -113,6 +105,10 @@ object Instance {
       Some(specs)
     )
   }
+
+  implicit val fields = new Fields[Instance] {
+    override def defaultFields: Seq[String] = Seq("stack", "stage", "app", "instanceName")
+  }
 }
 
 case class ManagementEndpoint(protocol:String, port:Int, path:String, url:String, format:String, source:String)
@@ -200,5 +196,12 @@ case class Instance(
 
   def prefixStage(prefix:String):Instance = {
     this.copy(stage = stage.map(s => s"$prefix$s"))
+  }
+}
+
+object InstanceCollectorSet extends CollectorSet[Instance](ResourceType("instance", 15 minutes, 1 minute)) {
+  val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
+    case json:JsonOrigin => JsonInstanceCollector(json, resource)
+    case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource)
   }
 }

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -15,12 +15,6 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-object LaunchConfigurationCollectorSet extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations", 1 hour, 5 minutes)) {
-  val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
-    case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource)
-  }
-}
-
 case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[LaunchConfiguration] with Logging {
 
   val client = AmazonAutoScalingClientBuilder.standard()
@@ -50,6 +44,10 @@ object LaunchConfiguration {
       }
     )
   }
+
+  implicit val fields = new Fields[LaunchConfiguration] {
+    override def defaultFields: Seq[String] = Seq("name", "imageId", "createdTime")
+  }
 }
 
 case class LaunchConfiguration(
@@ -65,4 +63,10 @@ case class LaunchConfiguration(
   securityGroups: List[String]
 ) extends IndexedItem {
   def callFromArn: (String) => Call = arn => routes.Api.launchConfiguration(arn)
+}
+
+object LaunchConfigurationCollectorSet extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations", 1 hour, 5 minutes)) {
+  val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
+    case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource)
+  }
 }

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -11,12 +11,6 @@ import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-object SecurityGroupCollectorSet extends CollectorSet[SecurityGroup](ResourceType("security-group", 1 hour, 5 minutes)) {
-  def lookupCollector: PartialFunction[Origin, Collector[SecurityGroup]] = {
-    case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource)
-  }
-}
-
 case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType)
     extends Collector[SecurityGroup] {
 
@@ -84,6 +78,16 @@ object SecurityGroup {
     override def item(arn: String): Option[(Label,SecurityGroup)] =
       Prism.securityGroupAgent.getTuples.find(_._2.arn==arn).headOption
   }
+
+  implicit val fields = new Fields[SecurityGroup] {
+    override def defaultFields: Seq[String] = Seq("groupId", "name", "vpcId")
+  }
 }
 
 case class SecurityGroupRef(groupId:String, account:String, arn:Option[String])
+
+object SecurityGroupCollectorSet extends CollectorSet[SecurityGroup](ResourceType("security-group", 1 hour, 5 minutes)) {
+  def lookupCollector: PartialFunction[Origin, Collector[SecurityGroup]] = {
+    case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource)
+  }
+}

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -11,12 +11,6 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-object Route53ZoneCollectorSet extends CollectorSet[Route53Zone](ResourceType("route53Zones", 1 hour, 5 minutes)) {
-  val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
-    case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource)
-  }
-}
-
 case class Route53ZoneCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Route53Zone] with Logging {
 
   val client = AmazonRoute53ClientBuilder.standard()
@@ -57,6 +51,10 @@ object Route53Zone {
       records = recordSets
     )
   }
+
+  implicit val fields = new Fields[Route53Zone] {
+    override def defaultFields: Seq[String] = Seq("name", "resourceRecordSetCount")
+  }
 }
 
 case class Route53Alias(dnsName: String, hostedZoneId: String, evaluateHealth: Boolean)
@@ -75,4 +73,10 @@ case class Route53Zone(
                            records: List[Route53Record]
                          ) extends IndexedItem {
   def callFromArn: (String) => Call = arn => routes.Api.route53Zone(arn)
+}
+
+object Route53ZoneCollectorSet extends CollectorSet[Route53Zone](ResourceType("route53-zones", 1 hour, 5 minutes)) {
+  val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
+    case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource)
+  }
 }

--- a/app/controllers/ApiResult.scala
+++ b/app/controllers/ApiResult.scala
@@ -1,16 +1,18 @@
 package controllers
 
 import play.api.libs.concurrent.Execution.Implicits._
+
 import scala.language.postfixOps
-import agent.{Origin, ResourceType, Label}
+import agent.{Fields, Label, Origin, ResourceType}
 import model.DataContainer
 import org.joda.time.DateTime
 import play.api.http.{ContentTypes, Status}
 import play.api.libs.json._
-import play.api.mvc.{Result, Results, RequestHeader}
+import play.api.mvc.{RequestHeader, Result, Results}
+
 import scala.concurrent.Future
 import scala.util.Try
-import utils.{ResourceFilter, Logging}
+import utils.{Logging, ResourceFilter}
 import jsonimplicits.joda._
 
 import scala.concurrent.duration._

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -2,10 +2,14 @@ package controllers
 
 import agent.CollectorAgent
 import collectors._
+import utils.Logging
 
-object Prism {
+object Prism extends Logging {
   val lazyStartup = conf.PrismConfiguration.accounts.lazyStartup
-  val instanceAgent = new CollectorAgent[Instance](InstanceCollectorSet, lazyStartup)
+  val instanceAgent = try {new CollectorAgent[Instance](InstanceCollectorSet, lazyStartup)} catch {
+    case t: Throwable => log.error("Error", t)
+      throw t
+  }
   val lambdaAgent = new CollectorAgent[Lambda](LambdaCollectorSet, lazyStartup)
   val dataAgent = new CollectorAgent[Data](DataCollectorSet, lazyStartup)
   val securityGroupAgent = new CollectorAgent[SecurityGroup](SecurityGroupCollectorSet, lazyStartup)

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -102,6 +102,8 @@ object model {
     }
   }
 
+  implicit val metadataWriter = Json.writes[Metadata]
+
   implicit def referenceReads[T](implicit idLookup:ArnLookup[T]): Reads[Reference[T]] = new Reads[Reference[T]] {
     override def reads(json: JsValue): JsResult[Reference[T]] = JsSuccess(Reference[T](json.as[String]))
   }

--- a/app/utils/CaseClassFieldList.scala
+++ b/app/utils/CaseClassFieldList.scala
@@ -1,0 +1,23 @@
+package utils
+
+object CaseClassFieldList extends Logging {
+  import scala.reflect.runtime.universe._
+
+  def allFields[T: TypeTag]: List[String] = {
+    def rec(tpe: Type): List[List[Name]] = {
+      val collected = tpe.members.collect {
+        case m: MethodSymbol if m.isCaseAccessor => m
+      }.toList
+      if (collected.nonEmpty)
+        collected.flatMap { m =>
+          m.returnType.typeArgs.headOption match {
+            case None => List(List(m.name))
+            case Some(t) => rec(t).map(m.name :: _)
+          }
+        }
+      else
+        List(Nil)
+    }
+    rec(typeOf[T]).map(_.mkString("."))
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -4,6 +4,7 @@
 
 GET        /                                  controllers.Application.index
 
+GET        /metadata                          controllers.Api.metadata
 # API V1
 GET        /sources                           controllers.Api.sources
 GET        /management/healthcheck            controllers.Api.healthCheck


### PR DESCRIPTION
As part of hackday activities @AWare suggested that it would be nice to have command line completion. This new `/metadata` endpoint lays the groundwork for that by exposing an endpoint that details the available endpoints and the fields in the objects that they return. This would allow a bash_completion script to be constructed that fetches (and hopefully caches) this endpoint and uses the data in it to complete the command line of prism.

It also provides a list of default fields for each type to inform a client which fields to display if none are specified. The `Fields` type class has necessitated re-ordering the collector classes as implicits will not be picked up if they are defined later in the same source file.

Todo:
 - [ ] Add some sensible descriptions for each endpoint
 - [ ] Consider rendering the same information on the home page of prism

For ease of review this is the current response of the endpoint on a local dev machine:
```json
{
  "status" : "success",
  "lastUpdated" : "2020-01-29T22:17:12.897Z",
  "stale" : false,
  "staleSources" : [ ],
  "data" : [ {
    "key" : "instance",
    "description" : "",
    "defaultFields" : [ "stack", "stage", "app", "instanceName" ],
    "allFields" : [ "specification.vpcId", "specification.instanceType", "specification.imageArn", "specification.imageId", "management", "role", "mainclasses", "app", "stack", "stage", "tags", "securityGroups.fields", "securityGroups.arn", "vendor", "region", "instanceName", "createdAt", "addresses", "ip", "dnsName", "group", "vendorState", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "lambda",
    "description" : "",
    "defaultFields" : [ "stack", "stage", "name" ],
    "allFields" : [ "stack", "stage", "tags", "runtime", "region", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "data",
    "description" : "",
    "defaultFields" : [ "key" ],
    "allFields" : [ "values.comment", "values.value", "values.stage", "values.app", "values.stack", "key", "meta.origin.resources", "meta.origin.url", "meta.origin.account", "meta.origin.vendor" ]
  }, {
    "key" : "security-group",
    "description" : "",
    "defaultFields" : [ "groupId", "name", "vpcId" ],
    "allFields" : [ "tags", "vpcId", "rules.sourceGroupRefs", "rules.sourceIpv6CidrBlocks", "rules.sourceIpv4CidrBlocks", "rules.toPort", "rules.fromPort", "rules.protocol", "location", "name", "groupId", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "images",
    "description" : "",
    "defaultFields" : [ "name", "imageId", "creationDate" ],
    "allFields" : [ "imageType", "rootDeviceType", "sriovNetSupport", "hypervisor", "virtualizationType", "ownerId", "architecture", "state", "creationDate", "tags", "description", "region", "imageId", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "launch-configurations",
    "description" : "",
    "defaultFields" : [ "name", "imageId", "createdTime" ],
    "allFields" : [ "securityGroups", "placementTenancy", "keyName", "instanceType", "createdTime", "instanceProfile", "region", "imageId", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "server-certificates",
    "description" : "",
    "defaultFields" : [ "id", "name", "expiryDate" ],
    "allFields" : [ "expiryDate", "uploadedAt", "path", "name", "id", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "acm-certificates",
    "description" : "",
    "defaultFields" : [ "domainName", "status", "notAfter" ],
    "allFields" : [ "renewalStatus.domainValidationOptions.validationStatus", "renewalStatus.domainValidationOptions.validationDomain", "renewalStatus.domainValidationOptions.validationEmails", "renewalStatus.domainValidationOptions.domainName", "renewalStatus.renewalStatus", "domainValidationOptions.validationStatus", "domainValidationOptions.validationDomain", "domainValidationOptions.validationEmails", "domainValidationOptions.domainName", "serial", "signatureAlgorithm", "keyAlgorithm", "subject", "failureReason", "issuedAt", "createdAt", "notAfter", "notBefore", "inUseBy", "issuer", "status", "certificateType", "subjectAlternativeNames", "domainName", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "route53-zones",
    "description" : "",
    "defaultFields" : [ "name", "resourceRecordSetCount" ],
    "allFields" : [ "records.aliasTarget.evaluateHealth", "records.aliasTarget.hostedZoneId", "records.aliasTarget.dnsName", "records.records", "records.ttl", "records.recordType", "records.name", "nameServers", "resourceRecordSetCount", "isPrivateZone", "comment", "callerReference", "id", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "loadBalancers",
    "description" : "",
    "defaultFields" : [ "name" ],
    "allFields" : [ "subnets", "availabilityZones", "scheme", "vpcId", "dnsName", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "bucket",
    "description" : "",
    "defaultFields" : [ "name", "region", "createdTime" ],
    "allFields" : [ "createdTime", "region", "name", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  }, {
    "key" : "reservation",
    "description" : "",
    "defaultFields" : [ "id", "instanceType", "instanceCount", "meta.origin.accountName" ],
    "allFields" : [ "endTime", "startTime", "offeringType", "instanceTenancy", "duration", "currencyCode", "state", "recurringCharges.amount", "recurringCharges.frequency", "usagePrice", "fixedPrice", "productDescription", "instanceCount", "instanceType", "region", "id", "arn", "meta.origin.ownerId", "meta.origin.accountNumber", "meta.origin.stagePrefix", "meta.origin.resources", "meta.origin.credentials", "meta.origin.region", "meta.origin.account" ]
  } ],
  "sources" : [ {
    "resource" : "metadata",
    "origin" : {
      "vendor" : "prism",
      "accountName" : "prism"
    },
    "status" : "success",
    "createdAt" : "2020-01-29T22:17:12.897Z",
    "itemCount" : 12,
    "age" : 7,
    "stale" : false
  } ]
}
```