### PR TITLE
Add DNS validation info to ACM certificates

### DIFF
--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -55,6 +55,7 @@ object model {
     Json.writes[Reservation]
   }
 
+  implicit val domainResourceRecordWriter = Json.writes[DomainResourceRecord]
   implicit val domainValidationWriter = Json.writes[DomainValidation]
   implicit val renewalInfoWriter = Json.writes[RenewalInfo]
   implicit val acmCertificateWriter = Json.writes[AcmCertificate]

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "1.11.518"
+val awsVersion = "1.11.759"
 
 libraryDependencies ++= Seq(
     "com.google.code.findbugs" % "jsr305" % "2.0.0",


### PR DESCRIPTION
Data about whether an ACM certificate was DNS or EMAIL validated wasn't available in Prism but would be super useful.