### PR TITLE
Deal with buckets being collected from multiple regions

### DIFF
--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -30,9 +30,10 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType) exte
 
   def crawl: Iterable[Bucket] = {
     val request = new ListBucketsRequest()
-    client.listBuckets(request).asScala.flatMap {
-      Bucket.fromApiData(_, client)
-    }
+    client.listBuckets(request).asScala
+      .flatMap {
+        Bucket.fromApiData(_, client)
+      }
   }
 }
 
@@ -43,14 +44,20 @@ object Bucket {
   def fromApiData(bucket: AWSBucket, client: AmazonS3): Option[Bucket] = {
     val bucketName = bucket.getName
     try {
-      Some(Bucket(
-        arn = arn(bucketName),
-        name = bucketName,
-        region = client.getBucketLocation(bucket.getName),
-        createdTime = Try(new DateTime(bucket.getCreationDate)).toOption
-      ))
+      val bucketRegion = client.getBucketLocation(bucket.getName)
+      if (bucketRegion == client.getRegionName) {
+        Some(Bucket(
+          arn = arn(bucketName),
+          name = bucketName,
+          region = bucketRegion,
+          createdTime = Try(new DateTime(bucket.getCreationDate)).toOption
+        ))
+      } else {
+        None
+      }
     } catch {
       case e:AmazonS3Exception if e.getErrorCode == "NoSuchBucket" => None
+      case e:AmazonS3Exception if e.getErrorCode == "AuthorizationHeaderMalformed" => None
       case NonFatal(t) =>
         throw new IllegalStateException(s"Failed when building info for bucket $bucketName", t)
     }


### PR DESCRIPTION
Two issues here
 - buckets are a global service so we need to filter them appropriately into the "owned" regions
 - if we are crawling `us-east-1` and we look at a bucket from another region all hell breaks loose: see https://github.com/aws/aws-sdk-java/issues/1338

Tested in CODE (with Prism configured to crawl `us-east-1` in addition to `eu-west-1`).