### PR TITLE
Decrease ACM polling inteval to 1 minute

### DIFF
--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 
-object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acmCertificates", 1 hour, 5 minutes)) {
+object AmazonCertificateCollectorSet extends CollectorSet[AcmCertificate](ResourceType("acmCertificates", 1 hour, 1 minute)) {
   val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
     case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource)
   }


### PR DESCRIPTION
Now we have a service that is carrying out validations every minute we should decrease the polling interval to match.