### PR TITLE
Switch to group email for security SAA

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -30,7 +30,7 @@ object Owners extends Owners {
   override def default = Owner("dig.dev.tooling")
 
   override def stacks: Set[(String, SSA)] = Set(
-    "adam.fisher" -> SSA("security"),
+    "security.dev" -> SSA("security"),
     "dotcom.platform" -> SSA("frontend"),
     "dotcom.platform" -> SSA("frontend-elk"),
     "identitydev" -> SSA(stack = "discussion"),


### PR DESCRIPTION
## What does this change?

Remove email address associated with individual and replace it with a group email.
@adamnfish does not escape as I have added him to the group anyway. /sorry

## How can we measure success?

More than one person receives AMIable alerts for outdated AMIs in the security stack 😁 

