### PR TITLE
Deal with null list of validation options

### DIFF
--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -76,7 +76,7 @@ case class RenewalInfo(renewalStatus: String, domainValidationOptions: List[Doma
 
 object RenewalInfo {
   def fromApiData(ri: RenewalSummary): RenewalInfo = {
-    RenewalInfo(ri.getRenewalStatus, ri.getDomainValidationOptions.asScala.map(DomainValidation.fromApiData).toList)
+    RenewalInfo(ri.getRenewalStatus, Option(ri.getDomainValidationOptions).map(_.asScala).getOrElse(Nil).map(DomainValidation.fromApiData).toList)
   }
 }
 


### PR DESCRIPTION
## What does this change?
A `FAILED` cert in multimedia was causing this code path to explode and therefore causing a failed schedule deploy of Prism. This has been tested locally and also will be in CODE shortly.

## How can we measure success?
Successful deploy into CODE.

