### PR TITLE
Add CI script for riffRaffNotifyTeamcity task 

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+sbt clean compile test riffRaffNotifyTeamcity


### PR DESCRIPTION
## What does this change?
Here we add a CI script for the `riffRaffNotifyTeamcity` task, so we can change teamcity's build runner from the SBT plugin to the Command Line. 

We decided to do this, because when building PR #84 the build failed with an ominous error: `java.lang.NoClassDefFoundError: sbt/TrackLevel`. We thought that if we could forego teamcity's use of the SBT plugin, we might solve the problem.

![Screenshot 2020-10-07 at 09 50 42](https://user-images.githubusercontent.com/42121379/95310297-2981a680-0884-11eb-9d02-8b80b21b9965.png)
https://teamcity.gutools.co.uk/buildConfiguration/Tools_Prism/580727?showLog=580727_217_42.217

## How to test
We're going to test by: 
1. changing the teamcity config to use the command line build runner and then,
1. merging this PR into Prism's main branch to see if teamcity can build it. If that's successful, we will
1. rebase PR #84 on top of master

![Screenshot 2020-10-07 at 09 40 58](https://user-images.githubusercontent.com/42121379/95308016-436dba00-0881-11eb-8e70-5511a3a81e0a.png)
https://teamcity.gutools.co.uk/admin/editRunType.html?id=buildType:Tools_Prism&runnerId=RUNNER_8&cameFromUrl=%2Fadmin%2FeditBuildRunners.html%3Fid%3DbuildType%253ATools_Prism%26init%3D1&cameFromTitle=

## How can we measure success?
It'll be successful if teamcity builds the `play-28-upgrade` branch without error, or at least gives us a more helpful error message!😂

## Have we considered potential risks?
If anything breaks, we can always revert teamcity's build runner back to the SBT plugin.
