### PR TITLE
Crawl all regions

### DIFF
--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -68,7 +68,6 @@ class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], sourceSt
       }
 
       val agent = ScheduledAgent[Datum[T]](0 seconds, collector.crawlRate.refreshPeriod, initial){ previous =>
-        // **we need the refreshPeriod here
         update(collector, previous)
       }
       collector -> agent
@@ -134,7 +133,7 @@ class SourceStatusAgent(actorSystem: ActorSystem) {
         val account = "prism"
         val resources = Set("sources")
         // TODO: change crawlRate parameters to smallestDuration
-        val crawlRate = Map("region" -> Map("sources" -> CrawlRate(1 minute, 1 minute)))
+        val crawlRate = Map(("sources" -> CrawlRate(1 minute, 1 minute)))
         val jsonFields = Map.empty[String, String]
       },
       statusList.size,

--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -9,6 +9,7 @@ import org.joda.time.DateTime
 import akka.actor.ActorSystem
 
 import scala.concurrent.ExecutionContext
+import scala.util.Random
 
 class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], sourceStatusAgent: SourceStatusAgent, lazyStartup:Boolean = true)(actorSystem: ActorSystem) extends CollectorAgentTrait[T] with Logging with LifecycleWithoutApp {
 
@@ -67,7 +68,9 @@ class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], sourceSt
         startupData
       }
 
-      val agent = ScheduledAgent[Datum[T]](0 seconds, collector.crawlRate.refreshPeriod, initial){ previous =>
+      val randomDelay = new Random().nextInt(60)
+
+      val agent = ScheduledAgent[Datum[T]](randomDelay seconds, collector.crawlRate.refreshPeriod, initial){ previous =>
         update(collector, previous)
       }
       collector -> agent

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -25,7 +25,7 @@ trait IndexedItemWithStack extends IndexedItem {
   val stack: Option[String] = None
 }
 
-abstract class CollectorSet[T](val resource: ResourceType, val crawlRate: CrawlRate, accounts: Accounts) extends Logging {
+abstract class CollectorSet[T](val resource: ResourceType, accounts: Accounts) extends Logging {
   def lookupCollector:PartialFunction[Origin, Collector[T]]
   def collectorFor(origin:Origin): Option[Collector[T]] = {
     if (lookupCollector.isDefinedAt(origin)) Some(lookupCollector(origin)) else None
@@ -62,7 +62,7 @@ case class Label(resourceType: ResourceType, origin:Origin, itemCount:Int, creat
   lazy val isError: Boolean = error.isDefined
   lazy val status: String = if (isError) "error" else "success"
   // TODO: improve the below
-  lazy val bestBefore: BestBefore = BestBefore(createdAt, origin.crawlRate("")(resourceType.name).shelfLife, error = isError)
+  lazy val bestBefore: BestBefore = BestBefore(createdAt, origin.crawlRate(resourceType.name).shelfLife, error = isError)
 }
 
 case class ResourceType(name: String) //shelfLife: FiniteDuration, refreshPeriod: FiniteDuration )

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -6,8 +6,9 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import scala.language.postfixOps
 import play.api.libs.json._
-import utils.Logging
+import utils.{Logging, Marker}
 import play.api.mvc.Call
+
 import scala.concurrent.duration._
 
 trait IndexedItem {
@@ -58,10 +59,12 @@ object Label {
   def apply[T](c: Collector[T], itemCount: Int): Label = Label(c.resource, c.origin, itemCount)
   def apply[T](c: Collector[T], error: Throwable): Label = Label(c.resource, c.origin, 0, error = Some(error))
 }
-case class Label(resourceType: ResourceType, origin:Origin, itemCount:Int, createdAt:DateTime = new DateTime(), error:Option[Throwable] = None) {
+case class Label(resourceType: ResourceType, origin:Origin, itemCount:Int, createdAt:DateTime = new DateTime(), error:Option[Throwable] = None) extends Marker {
   lazy val isError: Boolean = error.isDefined
   lazy val status: String = if (isError) "error" else "success"
   lazy val bestBefore: BestBefore = BestBefore(createdAt, origin.crawlRate(resourceType.name).shelfLife, error = isError)
+
+  override def toMarkerMap: Map[String, Any] = Map("resource" -> resourceType.name, "account" -> origin.account)
 }
 
 case class ResourceType(name: String)

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -25,7 +25,7 @@ trait IndexedItemWithStack extends IndexedItem {
   val stack: Option[String] = None
 }
 
-abstract class CollectorSet[T](val resource: ResourceType, accounts: Accounts) extends Logging {
+abstract class CollectorSet[T](val resource:ResourceType, accounts: Accounts) extends Logging {
   def lookupCollector:PartialFunction[Origin, Collector[T]]
   def collectorFor(origin:Origin): Option[Collector[T]] = {
     if (lookupCollector.isDefinedAt(origin)) Some(lookupCollector(origin)) else None
@@ -61,11 +61,10 @@ object Label {
 case class Label(resourceType: ResourceType, origin:Origin, itemCount:Int, createdAt:DateTime = new DateTime(), error:Option[Throwable] = None) {
   lazy val isError: Boolean = error.isDefined
   lazy val status: String = if (isError) "error" else "success"
-  // TODO: improve the below
   lazy val bestBefore: BestBefore = BestBefore(createdAt, origin.crawlRate(resourceType.name).shelfLife, error = isError)
 }
 
-case class ResourceType(name: String) //shelfLife: FiniteDuration, refreshPeriod: FiniteDuration )
+case class ResourceType(name: String)
 
 case class CrawlRate(shelfLife: FiniteDuration, refreshPeriod: FiniteDuration)
 

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -48,7 +48,7 @@ trait Origin {
   def account: String
   def filterMap: Map[String,String] = Map.empty
   def resources: Set[String]
-  def crawlRate: Map[String, Map[String, CrawlRate]]
+  def crawlRate: Map[String, CrawlRate]
   def transformInstance(input: Instance): Instance = input
   def standardFields: Map[String, String] = Map("vendor" -> vendor, "accountName" -> account)
   def jsonFields: Map[String, String]
@@ -76,7 +76,7 @@ case class Credentials(accessKey: Option[String], role: Option[String], profile:
 object AmazonOrigin {
   val ArnIamAccountExtractor: Regex = """arn:aws:iam::(\d+):role.*""".r
   def apply(account:String, region:String, resources:Set[String], stagePrefix: Option[String],
-            credentials: Credentials, ownerId: Option[String], crawlRates: Map[String, Map[String, CrawlRate]]): AmazonOrigin = {
+            credentials: Credentials, ownerId: Option[String], crawlRates: Map[String, CrawlRate]): AmazonOrigin = {
     val accountNumber = credentials.role.flatMap {
       case ArnIamAccountExtractor(accountId) => Some(accountId)
       case _ => None
@@ -85,13 +85,13 @@ object AmazonOrigin {
   }
 
   def amis(name: String, region: String, accountNumber: Option[String], credentials: Credentials,
-           ownerId: Option[String], crawlRates: Map[String, Map[String, CrawlRate]]): AmazonOrigin = {
+           ownerId: Option[String], crawlRates: Map[String, CrawlRate]): AmazonOrigin = {
     AmazonOrigin(name, region, credentials, Set("images"), None, accountNumber, ownerId, crawlRates)
   }
 }
 
 case class AmazonOrigin(account:String, region:String, credentials: Credentials, resources:Set[String],
-                        stagePrefix: Option[String], accountNumber:Option[String], ownerId: Option[String], crawlRate: Map[String, Map[String, CrawlRate]]) extends Origin {
+                        stagePrefix: Option[String], accountNumber:Option[String], ownerId: Option[String], crawlRate: Map[String, CrawlRate]) extends Origin {
   lazy val vendor = "aws"
   override lazy val filterMap = Map("vendor" -> vendor, "region" -> region, "accountName" -> account)
   override def transformInstance(input:Instance): Instance = stagePrefix.map(input.prefixStage).getOrElse(input)
@@ -100,7 +100,7 @@ case class AmazonOrigin(account:String, region:String, credentials: Credentials,
     ownerId.map("ownerId" -> _)
   val awsRegion: Regions = Regions.fromName(region)
 }
-case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String], crawlRate: Map[String, Map[String, CrawlRate]]) extends Origin with Logging {
+case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String], crawlRate: Map[String, CrawlRate]) extends Origin with Logging {
   private val classpathHandler = new URLStreamHandler {
     override def openConnection(u: URL): URLConnection = {
       Option(getClass.getResource(u.getPath)).map(_.openConnection()).getOrElse{

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -48,6 +48,7 @@ trait Origin {
   def account: String
   def filterMap: Map[String,String] = Map.empty
   def resources: Set[String]
+  def crawlRate: Map[String, Map[String, CrawlRate]]
   def transformInstance(input: Instance): Instance = input
   def standardFields: Map[String, String] = Map("vendor" -> vendor, "accountName" -> account)
   def jsonFields: Map[String, String]
@@ -75,22 +76,22 @@ case class Credentials(accessKey: Option[String], role: Option[String], profile:
 object AmazonOrigin {
   val ArnIamAccountExtractor: Regex = """arn:aws:iam::(\d+):role.*""".r
   def apply(account:String, region:String, resources:Set[String], stagePrefix: Option[String],
-            credentials: Credentials, ownerId: Option[String]): AmazonOrigin = {
+            credentials: Credentials, ownerId: Option[String], crawlRates: Map[String, Map[String, CrawlRate]]): AmazonOrigin = {
     val accountNumber = credentials.role.flatMap {
       case ArnIamAccountExtractor(accountId) => Some(accountId)
       case _ => None
     }
-    AmazonOrigin(account, region, credentials, resources, stagePrefix, accountNumber, ownerId)
+    AmazonOrigin(account, region, credentials, resources, stagePrefix, accountNumber, ownerId, crawlRates)
   }
 
   def amis(name: String, region: String, accountNumber: Option[String], credentials: Credentials,
-           ownerId: Option[String]): AmazonOrigin = {
-    AmazonOrigin(name, region, credentials, Set("images"), None, accountNumber, ownerId)
+           ownerId: Option[String], crawlRates: Map[String, Map[String, CrawlRate]]): AmazonOrigin = {
+    AmazonOrigin(name, region, credentials, Set("images"), None, accountNumber, ownerId, crawlRates)
   }
 }
 
 case class AmazonOrigin(account:String, region:String, credentials: Credentials, resources:Set[String],
-                        stagePrefix: Option[String], accountNumber:Option[String], ownerId: Option[String]) extends Origin {
+                        stagePrefix: Option[String], accountNumber:Option[String], ownerId: Option[String], crawlRate: Map[String, Map[String, CrawlRate]]) extends Origin {
   lazy val vendor = "aws"
   override lazy val filterMap = Map("vendor" -> vendor, "region" -> region, "accountName" -> account)
   override def transformInstance(input:Instance): Instance = stagePrefix.map(input.prefixStage).getOrElse(input)
@@ -99,7 +100,7 @@ case class AmazonOrigin(account:String, region:String, credentials: Credentials,
     ownerId.map("ownerId" -> _)
   val awsRegion: Regions = Regions.fromName(region)
 }
-case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String]) extends Origin with Logging {
+case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String], crawlRate: Map[String, Map[String, CrawlRate]]) extends Origin with Logging {
   private val classpathHandler = new URLStreamHandler {
     override def openConnection(u: URL): URLConnection = {
       Option(getClass.getResource(u.getPath)).map(_.openConnection()).getOrElse{

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -14,13 +14,13 @@ import scala.language.postfixOps
 import scala.util.Try
 
 
-class AmazonCertificateCollectorSet(accounts: Accounts) extends CollectorSet[AcmCertificate](ResourceType("acmCertificates", 1 hour, 1 minute), accounts) {
+class AmazonCertificateCollectorSet(accounts: Accounts) extends CollectorSet[AcmCertificate](ResourceType("acmCertificates"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
-    case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource)
+    case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSAcmCertificateCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[AcmCertificate] with Logging {
+case class AWSAcmCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[AcmCertificate] with Logging {
 
   val client: AWSCertificateManager = AWSCertificateManagerClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.certificatemanager.model.{CertificateDetail, DescribeCertificateRequest, ListCertificatesRequest, RenewalSummary, ResourceRecord, DomainValidation => AwsDomainValidation}
 import com.amazonaws.services.certificatemanager.{AWSCertificateManager, AWSCertificateManagerClientBuilder}
+import conf.AWS
 import controllers.routes
 import org.joda.time.DateTime
 import play.api.mvc.Call
@@ -25,6 +26,7 @@ case class AWSAcmCertificateCollector(origin: AmazonOrigin, resource: ResourceTy
   val client: AWSCertificateManager = AWSCertificateManagerClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[AcmCertificate] = PaginatedAWSRequest.run(client.listCertificates)(new ListCertificatesRequest()).map{ cert =>

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -15,13 +15,13 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 
-class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](ResourceType("bucket", 1 hour, 5 minutes), accounts) {
+class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](ResourceType("bucket"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Bucket]] = {
-    case amazon: AmazonOrigin => AWSBucketCollector(amazon, resource)
+    case amazon: AmazonOrigin => AWSBucketCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Bucket] with Logging {
+case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Bucket] with Logging {
 
   val client: AmazonS3 = AmazonS3ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.s3.model.{AmazonS3Exception, ListBucketsRequest, Bucket => AWSBucket}
+import conf.AWS
 import controllers.routes
 import org.joda.time.DateTime
 import play.api.mvc.Call
@@ -26,6 +27,7 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
   val client: AmazonS3 = AmazonS3ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[Bucket] = {

--- a/app/collectors/data.scala
+++ b/app/collectors/data.scala
@@ -9,13 +9,13 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.matching.Regex
 
-class DataCollectorSet(accounts: Accounts) extends CollectorSet[Data](ResourceType("data", 15 minutes, 1 minute), accounts) {
+class DataCollectorSet(accounts: Accounts) extends CollectorSet[Data](ResourceType("data"), accounts) {
   def lookupCollector: PartialFunction[Origin, Collector[Data]] = {
-    case json:JsonOrigin => JsonDataCollector(json, resource)
+    case json:JsonOrigin => JsonDataCollector(json, resource, json.crawlRate(resource.name))
   }
 }
 
-case class JsonDataCollector(origin:JsonOrigin, resource: ResourceType) extends JsonCollector[Data] {
+case class JsonDataCollector(origin:JsonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends JsonCollector[Data] {
   implicit val valueReads: Reads[Value] = Json.reads[Value]
   implicit val dataReads: Reads[Data] = Json.reads[Data]
   def crawl: Iterable[Data] = crawlJson

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeImagesRequest, Filter, Image => AWSImage}
+import conf.AWS
 import controllers.routes
 import org.joda.time.DateTime
 import play.api.mvc.Call
@@ -24,6 +25,7 @@ case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType, crawlRa
   val client: AmazonEC2 = AmazonEC2ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[Image] = {

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -13,13 +13,13 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Try
 
-class ImageCollectorSet(accounts:Accounts) extends CollectorSet[Image](ResourceType("images", 15 minutes, 1 minute), accounts) {
+class ImageCollectorSet(accounts:Accounts) extends CollectorSet[Image](ResourceType("images"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Image]] = {
-    case amazon:AmazonOrigin => AWSImageCollector(amazon, resource)
+    case amazon:AmazonOrigin => AWSImageCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType) extends Collector[Image] with Logging {
+case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType, crawlRate: CrawlRate) extends Collector[Image] with Logging {
 
   val client: AmazonEC2 = AmazonEC2ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -18,14 +18,14 @@ import agent._
 import scala.concurrent.duration._
 import scala.util.matching.Regex
 
-
-class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSet[Instance](ResourceType("instance", 15 minutes, 1 minute), accounts) {
+class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSet[Instance](ResourceType("instance"), CrawlRate(1 hour, 15 minutes), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
-    case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource, prism)
+        // I know this code is terrible, but it's just for testing the instance collector set
+    case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource, crawlRate, prism)
   }
 }
 
-case class AWSInstanceCollector(origin:AmazonOrigin, resource:ResourceType, prism: Prism) extends Collector[Instance] with Logging {
+case class AWSInstanceCollector(origin:AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate, prism: Prism) extends Collector[Instance] with Logging {
 
   val client: AmazonEC2 = AmazonEC2ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -18,10 +18,10 @@ import agent._
 import scala.concurrent.duration._
 import scala.util.matching.Regex
 
-class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSet[Instance](ResourceType("instance"), CrawlRate(1 hour, 15 minutes), accounts) {
+class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSet[Instance](ResourceType("instance"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
         // I know this code is terrible, but it's just for testing the instance collector set
-    case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource, crawlRate, prism)
+    case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource, amazon.crawlRate(resource.name), prism)
   }
 }
 

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -11,13 +11,13 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class LambdaCollectorSet(accounts: Accounts) extends CollectorSet[Lambda](ResourceType("lambda", 1 hour, 5 minutes), accounts) {
+class LambdaCollectorSet(accounts: Accounts) extends CollectorSet[Lambda](ResourceType("lambda"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Lambda]] = {
-    case amazon: AmazonOrigin => AWSLambdaCollector(amazon, resource)
+    case amazon: AmazonOrigin => AWSLambdaCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Lambda] with Logging {
+case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Lambda] with Logging {
 
   val client: AWSLambda = AWSLambdaClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.lambda.model.{FunctionConfiguration, ListFunctionsRequest, ListTagsRequest}
 import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
+import conf.AWS
 import controllers.routes
 import play.api.mvc.Call
 import utils.{Logging, PaginatedAWSRequest}
@@ -22,6 +23,7 @@ case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType, craw
   val client: AWSLambda = AWSLambdaClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[Lambda] = {

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -14,13 +14,13 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class LaunchConfigurationCollectorSet(accounts: Accounts) extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations", 1 hour, 5 minutes), accounts) {
+class LaunchConfigurationCollectorSet(accounts: Accounts) extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
-    case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource)
+    case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[LaunchConfiguration] with Logging {
+case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[LaunchConfiguration] with Logging {
 
   val client: AmazonAutoScaling = AmazonAutoScalingClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -9,6 +9,7 @@ import utils.{Logging, PaginatedAWSRequest}
 
 import scala.jdk.CollectionConverters._
 import com.amazonaws.services.autoscaling.model.{DescribeLaunchConfigurationsRequest, LaunchConfiguration => AWSLaunchConfiguration}
+import conf.AWS
 
 import scala.util.Try
 import scala.concurrent.duration._
@@ -25,6 +26,7 @@ case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: Resou
   val client: AmazonAutoScaling = AmazonAutoScalingClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[LaunchConfiguration] = {

--- a/app/collectors/loadBalancers.scala
+++ b/app/collectors/loadBalancers.scala
@@ -11,13 +11,13 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class LoadBalancerCollectorSet(accounts: Accounts) extends CollectorSet[LoadBalancer](ResourceType("loadBalancers", 1 hour, 5 minutes), accounts) {
+class LoadBalancerCollectorSet(accounts: Accounts) extends CollectorSet[LoadBalancer](ResourceType("loadBalancers"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[LoadBalancer]] = {
-    case amazon: AmazonOrigin => LoadBalancerCollector(amazon, resource)
+    case amazon: AmazonOrigin => LoadBalancerCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class LoadBalancerCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[LoadBalancer] with Logging {
+case class LoadBalancerCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[LoadBalancer] with Logging {
 
   val client: AmazonElasticLoadBalancing = AmazonElasticLoadBalancingClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/loadBalancers.scala
+++ b/app/collectors/loadBalancers.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancing, AmazonElasticLoadBalancingClientBuilder}
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeLoadBalancersRequest, LoadBalancerDescription}
+import conf.AWS
 import controllers.routes
 import play.api.mvc.Call
 import utils.{Logging, PaginatedAWSRequest}
@@ -22,6 +23,7 @@ case class LoadBalancerCollector(origin: AmazonOrigin, resource: ResourceType, c
   val client: AmazonElasticLoadBalancing = AmazonElasticLoadBalancingClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[LoadBalancer] = PaginatedAWSRequest.run(client.describeLoadBalancers)(new DescribeLoadBalancersRequest()).map{ elb =>

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeReservedInstancesRequest, ReservedInstances, RecurringCharge => AWSRecurringCharge}
+import conf.AWS
 import controllers.routes
 import org.joda.time.{DateTime, Duration}
 import play.api.mvc.Call
@@ -24,6 +25,7 @@ case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType,
   val client: AmazonEC2 = AmazonEC2ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[Reservation] = {

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -13,13 +13,13 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ReservationCollectorSet(accounts: Accounts) extends CollectorSet[Reservation](ResourceType("reservation", 15 minutes, 1 minute), accounts) {
+class ReservationCollectorSet(accounts: Accounts) extends CollectorSet[Reservation](ResourceType("reservation"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
-    case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource)
+    case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Reservation] with Logging {
+case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Reservation] with Logging {
 
   val client: AmazonEC2 = AmazonEC2ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -11,13 +11,13 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class SecurityGroupCollectorSet(accounts: Accounts, prismController: Prism) extends CollectorSet[SecurityGroup](ResourceType("security-group", 1 hour, 5 minutes), accounts) {
+class SecurityGroupCollectorSet(accounts: Accounts, prismController: Prism) extends CollectorSet[SecurityGroup](ResourceType("security-group"), accounts) {
   def lookupCollector: PartialFunction[Origin, Collector[SecurityGroup]] = {
-    case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource, prismController)
+    case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource, prismController, aws.crawlRate(resource.name))
   }
 }
 
-case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType, prismController: Prism)
+case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType, prismController: Prism, crawlRate: CrawlRate)
     extends Collector[SecurityGroup] {
 
   def fromAWS( secGroup: AWSSecurityGroup, lookup:Map[String,SecurityGroup]): SecurityGroup = {

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeSecurityGroupsRequest, IpPermission, SecurityGroup => AWSSecurityGroup}
+import conf.AWS
 import controllers.{Prism, routes}
 import play.api.mvc.Call
 import utils.PaginatedAWSRequest
@@ -52,6 +53,7 @@ case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType,
   val client: AmazonEC2 = AmazonEC2ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[SecurityGroup] = {

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.identitymanagement.{AmazonIdentityManagement, AmazonIdentityManagementClientBuilder}
 import com.amazonaws.services.identitymanagement.model.{ListServerCertificatesRequest, ServerCertificateMetadata}
+import conf.AWS
 import controllers.routes
 import org.joda.time.{DateTime, Duration}
 import play.api.mvc.Call
@@ -24,6 +25,7 @@ case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: Resourc
   val client: AmazonIdentityManagement = AmazonIdentityManagementClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[ServerCertificate] =

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -13,13 +13,13 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates", 1 hour, 5 minutes), accounts) {
+class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
-    case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource)
+    case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[ServerCertificate] with Logging {
+case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[ServerCertificate] with Logging {
 
   val client: AmazonIdentityManagement = AmazonIdentityManagementClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -11,13 +11,13 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class Route53ZoneCollectorSet(accounts: Accounts) extends CollectorSet[Route53Zone](ResourceType("route53Zones", 1 hour, 5 minutes), accounts) {
+class Route53ZoneCollectorSet(accounts: Accounts) extends CollectorSet[Route53Zone](ResourceType("route53Zones"), accounts) {
   val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
-    case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource)
+    case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
 }
 
-case class Route53ZoneCollector(origin: AmazonOrigin, resource: ResourceType) extends Collector[Route53Zone] with Logging {
+case class Route53ZoneCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Route53Zone] with Logging {
 
   val client: AmazonRoute53 = AmazonRoute53ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -3,6 +3,7 @@ package collectors
 import agent._
 import com.amazonaws.services.route53.{AmazonRoute53, AmazonRoute53ClientBuilder}
 import com.amazonaws.services.route53.model.{HostedZone, ListHostedZonesRequest, ListResourceRecordSetsRequest, ResourceRecordSet}
+import conf.AWS
 import controllers.routes
 import play.api.mvc.Call
 import utils.{Logging, PaginatedAWSRequest}
@@ -22,6 +23,7 @@ case class Route53ZoneCollector(origin: AmazonOrigin, resource: ResourceType, cr
   val client: AmazonRoute53 = AmazonRoute53ClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
     .withRegion(origin.awsRegion)
+    .withClientConfiguration(AWS.clientConfig)
     .build()
 
   def crawl: Iterable[Route53Zone] = PaginatedAWSRequest.run(client.listHostedZones)(new ListHostedZonesRequest()).map{ zone =>

--- a/app/conf/AWS.scala
+++ b/app/conf/AWS.scala
@@ -2,6 +2,7 @@ package conf
 
 import java.net.InetAddress
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Filter, DescribeTagsRequest => EC2DescribeTagsRequest}
@@ -14,6 +15,8 @@ import scala.util.Try
 
 object AWS extends Logging {
 
+  val clientConfig: ClientConfiguration = new ClientConfiguration().withMaxErrorRetry(10)
+
   // This is to detect if we are running in AWS or on GC2. The 169.254.169.254
   // thing works on both but this DNS entry seems peculiar to AWS.
   lazy val isAWS: Boolean = Try(InetAddress.getByName("instance-data")).isSuccess
@@ -21,7 +24,7 @@ object AWS extends Logging {
 
   lazy val connectionRegion: Regions = instance.region.getOrElse(Regions.EU_WEST_1)
 
-  lazy val EC2Client: AmazonEC2 = AmazonEC2ClientBuilder.standard().withRegion(connectionRegion).build()
+  lazy val EC2Client: AmazonEC2 = AmazonEC2ClientBuilder.standard().withRegion(connectionRegion).withClientConfiguration(clientConfig).build()
 
   type Tag = (String, String)
 

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -7,6 +7,7 @@ import play.api.{Configuration, Mode}
 import agent._
 import java.net.URL
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 
 import scala.jdk.CollectionConverters._

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -46,7 +46,7 @@ class PrismConfiguration(configuration: Configuration) extends Logging {
     lazy val allRegions = {
       val ec2Client = AmazonEC2AsyncClientBuilder.standard().withRegion(Regions.EU_WEST_1).build()
       try {
-        val request = new DescribeRegionsRequest() //.withAllRegions(true)
+        val request = new DescribeRegionsRequest() //.withAllRegions(true) - let's add this back in once DeployTools has access to all regions
         val response = ec2Client.describeRegions(request)
         val regions = response.getRegions.asScala.toList.map(_.getRegionName)
         regions

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -51,7 +51,7 @@ class PrismConfiguration(configuration: Configuration) extends Logging {
     }
 
     object aws {
-      lazy val regionsToCrawl: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsDefault").getOrElse(allRegions)
+      lazy val regionsToCrawl: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsToCrawl").getOrElse(allRegions)
       lazy val highPriorityRegions: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsHighPriority").getOrElse(Seq("eu-west-1"))
       lazy val crawlRates = getCrawlRates(highPriorityRegions)
       lazy val defaultOwnerId: Option[String] = configuration.getOptional[String]("accounts.aws.defaultOwnerId")

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -1,23 +1,16 @@
 package conf
 
-import utils.{Logging, UnnaturalOrdering}
-
-import scala.language.postfixOps
-import play.api.{Configuration, Mode}
 import agent._
-import java.net.URL
-
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-
-import scala.jdk.CollectionConverters._
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.AmazonEC2AsyncClientBuilder
 import com.amazonaws.services.ec2.model.DescribeRegionsRequest
-import conf.AWS.instance.region
 import conf.PrismConfiguration.getCrawlRates
+import play.api.{Configuration, Mode}
+import utils.{Logging, UnnaturalOrdering}
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -47,7 +40,7 @@ class PrismConfiguration(configuration: Configuration) extends Logging {
     lazy val allRegions = {
       val ec2Client = AmazonEC2AsyncClientBuilder.standard().withRegion(Regions.EU_WEST_1).build()
       try {
-        val request = new DescribeRegionsRequest() //.withAllRegions(true) - let's add this back in once DeployTools has access to all regions
+        val request = new DescribeRegionsRequest() 
         val response = ec2Client.describeRegions(request)
         val regions = response.getRegions.asScala.toList.map(_.getRegionName)
         regions

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -3,20 +3,17 @@ package controllers
 import agent._
 import collectors._
 import conf.PrismConfiguration
-import play.api.Logging
-import play.api.mvc._
-import play.api.mvc.{Action, RequestHeader, Result}
-import play.api.libs.json._
-import play.api.libs.json.Json._
 import play.api.http.Status
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.language.postfixOps
+import play.api.libs.json.Json._
+import play.api.libs.json._
+import play.api.mvc.{Action, RequestHeader, Result, _}
 import utils.{Matchable, ResourceFilter}
 
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
 //noinspection TypeAnnotation
-class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: PrismConfiguration)(implicit executionContext: ExecutionContext) extends AbstractController(cc) with Logging {
+class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: PrismConfiguration)(implicit executionContext: ExecutionContext) extends AbstractController(cc) {
     implicit def referenceWrites[T <: IndexedItem](implicit arnLookup:ArnLookup[T], tWrites:Writes[T], request: RequestHeader): Writes[Reference[T]] = (o: Reference[T]) => {
       request.getQueryString("_reference") match {
         case Some("inline") =>
@@ -90,9 +87,9 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
         val notInitialisedSources = sources.data.filter(_.state.status != "success")
         if (notInitialisedSources.isEmpty) Map.empty else Map(sources.label -> notInitialisedSources)
       } reduce { notInitialisedSources =>
-        if (notInitialisedSources.isEmpty)
+        if (notInitialisedSources.isEmpty) {
           Json.obj("healthcheck" -> "initialised")
-        else
+        } else
           throw ApiCallException(Json.obj("healthcheck" -> "not yet initialised", "sources" -> notInitialisedSources.values.headOption), SERVICE_UNAVAILABLE)
       }
     }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -110,7 +110,7 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
         val results = sources.flatMap { case (label, dataItems) =>
           dataItems.map { data =>
             Json.obj(
-              "type" -> label.resource.name,
+              "type" -> label.resourceType.name,
               "href" -> data.call.absoluteURL()
             )
           }

--- a/app/controllers/ApiResult.scala
+++ b/app/controllers/ApiResult.scala
@@ -130,6 +130,8 @@ object ApiResult extends Logging {
         val resources = Set.empty[String]
         val jsonFields = Map.empty[String, String]
         val crawlRate = Map(noSourceContainer.name -> CrawlRate(15 minutes, 1 minutes))
+
+        override def toMarkerMap: Map[String, Any] = jsonFields
       },
       1,
       noSourceContainer.lastUpdated

--- a/app/controllers/ApiResult.scala
+++ b/app/controllers/ApiResult.scala
@@ -129,7 +129,7 @@ object ApiResult extends Logging {
         val vendor = "unknown"
         val resources = Set.empty[String]
         val jsonFields = Map.empty[String, String]
-        val crawlRate = Map.empty[String, CrawlRate]
+        val crawlRate = Map(noSourceContainer.name -> CrawlRate(15 minutes, 1 minutes))
       },
       1,
       noSourceContainer.lastUpdated

--- a/app/controllers/ApiResult.scala
+++ b/app/controllers/ApiResult.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import scala.language.postfixOps
-import agent.{Label, Origin, ResourceType}
+import agent.{CrawlRate, Label, Origin, ResourceType}
 import model.DataContainer
 import org.joda.time.DateTime
 import play.api.http.{ContentTypes, Status}
@@ -123,12 +123,13 @@ object ApiResult extends Logging {
 
   def noSource(block: => JsValue)(implicit request:RequestHeader, ec: ExecutionContext): Future[Result] = {
     val sourceLabel:Label = Label(
-      ResourceType(noSourceContainer.name, 15 minutes, 1 minute),
+      ResourceType(noSourceContainer.name),
       new Origin {
         val account = "unknown"
         val vendor = "unknown"
         val resources = Set.empty[String]
         val jsonFields = Map.empty[String, String]
+        val crawlRate = Map.empty[String, CrawlRate]
       },
       1,
       noSourceContainer.lastUpdated

--- a/app/controllers/OwnerApi.scala
+++ b/app/controllers/OwnerApi.scala
@@ -37,6 +37,8 @@ class OwnerApi(cc: ControllerComponents)(implicit executionContext: ExecutionCon
         val resources = Set("sources")
         val jsonFields = Map.empty[String, String]
         val crawlRate = Map("Owners" -> CrawlRate(30 days, 30 days))
+
+        override def toMarkerMap: Map[String, Any] = jsonFields
       },
       Owners.all.size,
       DateTime.now

--- a/app/controllers/OwnerApi.scala
+++ b/app/controllers/OwnerApi.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import agent.{Label, Origin, ResourceType}
+import agent.{CrawlRate, Label, Origin, ResourceType}
 import data.Owners
 import jsonimplicits.model._
 import model.Owner
@@ -9,6 +9,7 @@ import play.api.mvc._
 import play.api.mvc.{RequestHeader, Result}
 import play.api.libs.json.{JsObject, Json, Writes}
 import play.api.libs.json.Json._
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -26,7 +27,7 @@ class OwnerApi(cc: ControllerComponents)(implicit executionContext: ExecutionCon
       }
     }
 
-    object OwnerResourceType extends ResourceType("Owners", 30 days, 30 days)
+    object OwnerResourceType extends ResourceType("Owners")
 
     val ownerLabel: Label = Label(
       OwnerResourceType,
@@ -35,6 +36,7 @@ class OwnerApi(cc: ControllerComponents)(implicit executionContext: ExecutionCon
         val account = "prism"
         val resources = Set("sources")
         val jsonFields = Map.empty[String, String]
+        val crawlRate = Map("Owners" -> CrawlRate(30 days, 30 days))
       },
       Owners.all.size,
       DateTime.now

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -4,10 +4,12 @@ import agent.{Accounts, CollectorAgent, SourceStatusAgent}
 import akka.actor.ActorSystem
 import collectors._
 import conf.PrismConfiguration
+import utils.StopWatch
 
 // TODO: Maybe we should refactor this to be PrismAgents and to not be in the controllers package?
 class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
-  val sourceStatusAgent = new SourceStatusAgent(actorSystem)
+  val prismRunTimeStopWatch = new StopWatch
+  val sourceStatusAgent = new SourceStatusAgent(actorSystem, prismRunTimeStopWatch)
   val accounts = new Accounts(prismConfiguration)
 
   val lazyStartup: Boolean = prismConfiguration.accounts.lazyStartup

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -8,7 +8,7 @@ import utils.StopWatch
 
 // TODO: Maybe we should refactor this to be PrismAgents and to not be in the controllers package?
 class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
-  val prismRunTimeStopWatch = new StopWatch
+  val prismRunTimeStopWatch = new StopWatch()
   val sourceStatusAgent = new SourceStatusAgent(actorSystem, prismRunTimeStopWatch)
   val accounts = new Accounts(prismConfiguration)
 

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -64,7 +64,7 @@ object model {
 
   implicit val labelWriter:Writes[Label] = (l: Label) => {
     Json.obj(
-      "resource" -> l.resource.name,
+      "resource" -> l.resourceType.name,
       "origin" -> l.origin
     ) ++ basicLabelWriter.writes(l).as[JsObject]
   }
@@ -90,7 +90,7 @@ object model {
     implicit val writes: OWrites[SourceStatus] = Json.writes[SourceStatus]
     def writes(o: SourceStatus): JsValue = {
       Json.obj(
-        "resource" -> o.state.resource.name,
+        "resource" -> o.state.resourceType.name,
         "origin" -> o.state.origin,
         "status" -> o.latest.status
       ) ++ Json.toJson(o).as[JsObject]

--- a/app/utils/Marker.scala
+++ b/app/utils/Marker.scala
@@ -1,0 +1,5 @@
+package utils
+
+trait Marker {
+  def toMarkerMap: Map[String, Any]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "1.11.759"
+val awsVersion = "1.11.887"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, BuildInfoPlugin)

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -4,7 +4,7 @@ import play.api.libs.json.{JsArray, _}
 import play.api.mvc._
 import play.api.test._
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -76,16 +76,18 @@ object ApiSpec extends PlaySpecification with Results {
   }
 
   class TestOrigin extends Origin {
+    private val duration = FiniteDuration(1, "s")
+
     def vendor: String = "vendor"
     def account: String = "account"
     def resources: Set[String] = Set("resources")
     def jsonFields: Map[String, String] = Map("key" -> "value")
+    def crawlRate: Map[String, CrawlRate] = Map("test" -> CrawlRate(duration, duration))
   }
 
 
   class TestCollectorAgent extends CollectorAgentTrait[TestItem] {
-    private val duration = FiniteDuration(1, "s")
-    private val resourceType = ResourceType("test", duration, duration)
+    private val resourceType = ResourceType("test")
     private val label = Label(resourceType, new TestOrigin, 1)
 
     def get(collector: Collector[TestItem]): Datum[TestItem] = Datum(label, Seq(TestItem("arn", "name", "region")))

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -83,6 +83,8 @@ object ApiSpec extends PlaySpecification with Results {
     def resources: Set[String] = Set("resources")
     def jsonFields: Map[String, String] = Map("key" -> "value")
     def crawlRate: Map[String, CrawlRate] = Map("test" -> CrawlRate(duration, duration))
+
+    override def toMarkerMap: Map[String, Any] = jsonFields
   }
 
 

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -76,13 +76,13 @@ object ApiSpec extends PlaySpecification with Results {
   }
 
   class TestOrigin extends Origin {
-    private val duration = FiniteDuration(1, "s")
+    private val oneSecond = FiniteDuration(1, "s")
 
     def vendor: String = "vendor"
     def account: String = "account"
     def resources: Set[String] = Set("resources")
     def jsonFields: Map[String, String] = Map("key" -> "value")
-    def crawlRate: Map[String, CrawlRate] = Map("test" -> CrawlRate(duration, duration))
+    def crawlRate: Map[String, CrawlRate] = Map("test" -> CrawlRate(oneSecond, oneSecond))
 
     override def toMarkerMap: Map[String, Any] = jsonFields
   }

--- a/test/conf/PrismConfigurationSpec.scala
+++ b/test/conf/PrismConfigurationSpec.scala
@@ -1,0 +1,21 @@
+package conf
+
+import org.specs2.mutable._
+
+class PrismConfigurationSpec extends Specification {
+  "getCrawlRate" should {
+    val crawlRates = PrismConfiguration.getCrawlRates(Seq("eu-west-1", "us-east-1"))
+    "return a fastCrawl for eu-west-1 and an instance resource" in {
+      crawlRates("eu-west-1")("instance") should equalTo(PrismConfiguration.fastCrawl)
+    }
+    "return a slowCrawl for a test region and an instance resource" in {
+      crawlRates("test")("instance") should equalTo(PrismConfiguration.slowCrawl)
+    }
+    "return a slowCrawl for eu-west-1 and a test resource" in {
+      crawlRates("eu-west-1")("test") should equalTo(PrismConfiguration.slowCrawl)
+    }
+    "return a slowCrawl for test region and test resource" in {
+      crawlRates("test")("test") should equalTo(PrismConfiguration.slowCrawl)
+    }
+  }
+}

--- a/test/conf/PrismConfigurationSpec.scala
+++ b/test/conf/PrismConfigurationSpec.scala
@@ -6,16 +6,19 @@ class PrismConfigurationSpec extends Specification {
   "getCrawlRate" should {
     val crawlRates = PrismConfiguration.getCrawlRates(Seq("eu-west-1", "us-east-1"))
     "return a fastCrawl for eu-west-1 and an instance resource" in {
-      crawlRates("eu-west-1")("instance") should equalTo(PrismConfiguration.fastCrawl)
+      crawlRates("eu-west-1")("instance") should equalTo(PrismConfiguration.fastCrawlRate)
     }
-    "return a slowCrawl for a test region and an instance resource" in {
-      crawlRates("test")("instance") should equalTo(PrismConfiguration.slowCrawl)
+    "return a mediumCrawl for a test region and an instance resource" in {
+      crawlRates("test")("instance") should equalTo(PrismConfiguration.slowCrawlRate)
     }
-    "return a slowCrawl for eu-west-1 and a test resource" in {
-      crawlRates("eu-west-1")("test") should equalTo(PrismConfiguration.slowCrawl)
+    "return a mediumCrawl for eu-west-1 and a test resource" in {
+      crawlRates("eu-west-1")("test") should equalTo(PrismConfiguration.defaultCrawlRate)
     }
-    "return a slowCrawl for test region and test resource" in {
-      crawlRates("test")("test") should equalTo(PrismConfiguration.slowCrawl)
+    "return a mediumCrawl for test region and test resource" in {
+      crawlRates("test")("test") should equalTo(PrismConfiguration.slowCrawlRate)
+    }
+    "return a slowCrawlRate for all resources in low priority regions" in {
+      crawlRates("af-south-1")("test") should equalTo(PrismConfiguration.slowCrawlRate)
     }
   }
 }

--- a/test/conf/PrismConfigurationSpec.scala
+++ b/test/conf/PrismConfigurationSpec.scala
@@ -5,19 +5,19 @@ import org.specs2.mutable._
 class PrismConfigurationSpec extends Specification {
   "getCrawlRate" should {
     val crawlRates = PrismConfiguration.getCrawlRates(Seq("eu-west-1", "us-east-1"))
-    "return a fastCrawl for eu-west-1 and an instance resource" in {
+    "return a fast crawl rate for eu-west-1 and an instance resource" in {
       crawlRates("eu-west-1")("instance") should equalTo(PrismConfiguration.fastCrawlRate)
     }
-    "return a mediumCrawl for a test region and an instance resource" in {
-      crawlRates("test")("instance") should equalTo(PrismConfiguration.slowCrawlRate)
-    }
-    "return a mediumCrawl for eu-west-1 and a test resource" in {
+    "return a default crawl rate for eu-west-1 and a test resource" in {
       crawlRates("eu-west-1")("test") should equalTo(PrismConfiguration.defaultCrawlRate)
     }
-    "return a mediumCrawl for test region and test resource" in {
+    "return a slow crawl rate for a test region and an instance resource" in {
+      crawlRates("test")("instance") should equalTo(PrismConfiguration.slowCrawlRate)
+    }
+    "return a slow crawl rate for test region and test resource" in {
       crawlRates("test")("test") should equalTo(PrismConfiguration.slowCrawlRate)
     }
-    "return a slowCrawlRate for all resources in low priority regions" in {
+    "return a slow crawl rate for all resources in low priority regions" in {
       crawlRates("af-south-1")("test") should equalTo(PrismConfiguration.slowCrawlRate)
     }
   }


### PR DESCRIPTION
## What is the problem? ⭐️

Currently, it is not easy for us to find out if an Amazon resource has been created in a region outside of the Guardian's preferred regions. This is a particular problem for Infosec who get asked questions like,
> "Given an ELB CNAME, can I determine if the resource is in one of our AWS organisation accounts, and if so which account?"

As well as this, we can't rule out if we've been compromised by a hostile third party if we do not have visibility over our resources in all regions. Up until now, Kate sometimes uses Cloudmapper to collect data from AWS accounts but it's not a great experience to run locally: https://github.com/duo-labs/cloudmapper

After speaking to @katebee, we received the following requirements for this work:
1. crawl all regions for AWS assets once a day, or even once per week
2. rule out that there are no AWS assets in other regions
3. once we know which regions we have assets in, Infosec could consider using service control policies to limit guardian users creating assets outside of our desired regions (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#examples_general).

## Describe the solution ⭐️

Therefore, the idea was put forward for prism to crawl all regions, instead of just the mostly eu-west-1 that it crawls currently. This means that it's easy for our Infosec colleagues to find the information they are looking for.

This PR is only the first part of this work. Here, we have:
- split out the shelfLife and refreshPeriod from the ResourceType into a CrawlRate case class, so that we were able to create some central logic that governs all of the crawlRates for the controllers. Previously they were hardcoded into each controller.
- used aws's describeRegions API, which returns all the regions we have access to. See next steps for further work to be done on this.
- we've designed the code that determines crawl rates so that it is easy to test and we've written a test that checks that given a resource type and region, we return the correct crawl rate.
- we've also created layers of overrides, so that prism's config, which lives in dynamoDB can be used to override the logic in the code, both at the Guardian account level and for prism as a whole.

## Next steps ⭐️

Whilst this PR introduces the bulk of the code changes required for this work, there are some significant outstanding issues before this feature is complete:

### AWS rate limits
We're currently hitting rate limits. We tried to solve this by adding a random delay to the scheduled agent, but this only partially worked. My advice for colleagues here would be to:
- understand how the collectors work, so that we know where exactly to add a random delay. It might be the case that where we've added it is not having the most impact. Each collector is initiated when prism starts up and it then starts making its requests. Instead of adding a random delay to the initiation per collector (which is I think what we've done here, although I may be wrong having not looked into it in detail yet), we could look at doing this one level down, at each collector so the timing _their_ requests to all regions are randomised. 

### Access to all regions
The deploy tools account in which prism lives does not have access to all-regions. The describeRegions API returns all the regions we have available to us, which is 16. However with the all-regions option set to true, we should receive 21 regions. The best way to go about this might be to:
- first speak to @katebee about prism getting access to all regions and how this might work
- double check that we can get access to `ap-northeast-3` (Asia Pacific (Osaka-Local)) as when we tried using the aws cli tool with the all-regions flag, that was the one region we didn't have access to that we should have. Here's the aws cli command: `aws ec2 describe-regions --region eu-west-1 --all-regions`.

## How to test  ⭐️
We've tested this PR by deploying it to Prism CODE successfully, with just 2 regions in prism's CODE config (`accounts.aws.regionsDefault`). This is very far away from the 21 regions we hope prism can crawl when this work is complete. A good way to test progress on this work is to slowly increase the number of regions in config, before removing them so that we fall back to the `allRegions` variable introduced in this PR.

## How can we measure success?  ⭐️
Success would be this feature making our Infosec colleagues happy 🥰😍🥰

## Have we considered potential risks?  ⭐️
TBD
