### PR TITLE
log which AWS profile is used to aid debugging

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,8 +1,7 @@
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
 import conf.{AWS, DynamoConfiguration, FileConfiguration, Identity}
-import play.api.{Application, ApplicationLoader, Configuration, LoggerConfigurator, Mode}
-import utils.Logging
+import play.api._
+import utils.{Logging, AWSCredentialProviders}
 
 class AppLoader extends ApplicationLoader with Logging {
   def load(context: ApplicationLoader.Context): Application = {
@@ -21,7 +20,7 @@ class AppLoader extends ApplicationLoader with Logging {
 
     val extraConfigs = List(
       DynamoConfiguration(
-        new DefaultAWSCredentialsProviderChain(),
+        AWSCredentialProviders.deployToolsCredentialsProviderChain,
         Regions.EU_WEST_1,
         identity
       ),

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -12,7 +12,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import conf.{AWS, PrismConfiguration}
 import play.api.libs.json.{JsObject, JsValue, Json}
-import utils.Logging
+import utils.{Logging, AWSCredentialProviders}
 
 import scala.io.Source
 import scala.language.postfixOps
@@ -68,7 +68,7 @@ case class Credentials(accessKey: Option[String], role: Option[String], profile:
       (p, new ProfileCredentialsProvider(p))
     case (Some(ak), Some(sk), _, _) =>
       (ak, new AWSStaticCredentialsProvider(new BasicAWSCredentials(ak, sk)))
-    case _ => ("default", new DefaultAWSCredentialsProviderChain())
+    case _ => ("default", AWSCredentialProviders.deployToolsCredentialsProviderChain)
   }
 }
 
@@ -112,7 +112,7 @@ case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[S
     Option(url.getUserInfo) match {
       case Some(role) if role.startsWith("arn:") => new STSAssumeRoleSessionCredentialsProvider.Builder(role, "prismS3").build()
       case Some(profile) => new ProfileCredentialsProvider(profile)
-      case _ => new DefaultAWSCredentialsProviderChain()
+      case _ => AWSCredentialProviders.deployToolsCredentialsProviderChain
     }
   }
 

--- a/app/utils/AWSCredentialProviders.scala
+++ b/app/utils/AWSCredentialProviders.scala
@@ -1,0 +1,16 @@
+package utils
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+
+object AWSCredentialProviders extends Logging {
+  def profileCredentialsProvider(profileName: String) = {
+    log.info(s"Using $profileName profile credentials")
+    new ProfileCredentialsProvider(profileName)
+  }
+
+  def deployToolsCredentialsProviderChain: AWSCredentialsProviderChain = new AWSCredentialsProviderChain(
+    profileCredentialsProvider("deployTools"),
+    new DefaultAWSCredentialsProviderChain()
+  )
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently in DEV we need numerous AWS credentials:
- a set for the default profile
- a set for each profile defined in config

If we do not have one of these credentials, we get are greeted with an exception from the AWS SDK. The exception is fairly descriptive `The security token included in the request is expired`, however it's not clear which set of credentials are not valid.

This change adds a log line in an attempt to make it easier to understand which credentials are not valid. That is, the logs will look something like below, where the profile is echoed next to the Exception.

🚨 This change also moves to using the `deployTools` profile rather than the `default` profile when fetching config from DynamoDb. This is more inline with our other apps.

```
2020-10-27 13:31:12,474 [play-dev-mode-akka.actor.default-dispatcher-7] INFO  {} utils.AWSCredentialProviders:8 - Using deployTools profile credentials
2020-10-27 13:31:13,510 [play-dev-mode-akka.actor.default-dispatcher-7] ERROR {} p.api.http.DefaultHttpErrorHandler:299 -

! @7hhilcbmg - Internal server error, for (GET) [/] ->

play.api.UnexpectedException: Unexpected exception[AmazonDynamoDBException: The security token included in the request is expired (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ExpiredTokenException; Request ID: S2D28D1UH70E99QGO924ADGEANVV4KQNSO5AEMVJF66Q9ASUAAJG)]
	at play.core.server.DevServerStart$$anon$1.reload(DevServerStart.scala:211)
	at play.core.server.DevServerStart$$anon$1.get(DevServerStart.scala:142)
	at play.core.server.AkkaHttpServer.handleRequest(AkkaHttpServer.scala:301)
	at play.core.server.AkkaHttpServer.$anonfun$createServerBinding$1(AkkaHttpServer.scala:191)
	at akka.stream.impl.fusing.MapAsync$$anon$30.onPush(Ops.scala:1285)
	at akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:541)
	at akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:423)
	at akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:625)
	at akka.stream.impl.fusing.GraphInterpreterShell$AsyncInput.execute(ActorGraphInterpreter.scala:502)
	at akka.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter.scala:600)
	at akka.stream.impl.fusing.ActorGraphInterpreter.akka$stream$impl$fusing$ActorGraphInterpreter$$processEvent(ActorGraphInterpreter.scala:769)
	at akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(ActorGraphInterpreter.scala:784)
	at akka.actor.Actor.aroundReceive(Actor.scala:535)
	at akka.actor.Actor.aroundReceive$(Actor.scala:533)
	at akka.stream.impl.fusing.ActorGraphInterpreter.aroundReceive(ActorGraphInterpreter.scala:691)
Caused by: com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException: The security token included in the request is expired (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ExpiredTokenException; Request ID: S2D28D1UH70E99QGO924ADGEANVV4KQNSO5AEMVJF66Q9ASUAAJG)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1799)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1383)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1359)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1139)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:796)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:764)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:738)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:698)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:680)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:544)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:524)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.doInvoke(AmazonDynamoDBClient.java:5110)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.invoke(AmazonDynamoDBClient.java:5077)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.executeBatchGetItem(AmazonDynamoDBClient.java:509)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.batchGetItem(AmazonDynamoDBClient.java:475)
2020-10-27 13:31:32,452 [play-dev-mode-shutdown-hook-1] INFO  {} play.core.server.AkkaHttpServer:461 - Stopping Akka HTTP server...
2020-10-27 13:31:32,458 [play-dev-mode-akka.actor.internal-dispatcher-4] INFO  {} play.core.server.AkkaHttpServer:472 - Terminating server binding for /0:0:0:0:0:0:0:0:9000
2020-10-27 13:31:32,477 [play-dev-mode-akka.actor.internal-dispatcher-4] INFO  {} play.core.server.AkkaHttpServer:490 - Running provided shutdown stop hooks
2020-10-27 13:31:32,477 [play-dev-mode-akka.actor.default-dispatcher-7] WARN  {akkaAddress=akka://play-dev-mode, sourceThread=play-dev-mode-akka.actor.internal-dispatcher-4, akkaSource=CoordinatedShutdown(akka://play-dev-mode), sourceActorSystem=play-dev-mode, akkaTimestamp=13:31:32.476UTC} akka.actor.CoordinatedShutdown:90 - Task [shutdown-application-dev-mode] failed in phase [service-stop]: Unexpected exception[AmazonDynamoDBException: The security token included in the request is expired (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ExpiredTokenException; Request ID: S2D28D1UH70E99QGO924ADGEANVV4KQNSO5AEMVJF66Q9ASUAAJG)]
```

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Checkout branch
- Run app with invalid/expired credentials
- Witness the ease at which you can debug the issue

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Better developer experience?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a