### PR TITLE
Ship logs to central ELK

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -30,15 +30,13 @@ class AppLoader extends ApplicationLoader with Logging {
 
     val extraConfig: Configuration = extraConfigs.foldRight(Configuration.empty)(_.configuration(context.environment.mode).withFallback(_))
 
-    val role: Option[String] = extraConfig.getOptional[String]("accounts.LoggingRole")
-    val stream: Option[String] = extraConfig.getOptional[String]("accounts.LoggingStream")
-
-    (role, stream) match {
-      case (Some(role), Some(stream)) =>
-        LogConfiguration.shipping(role, stream, identity)
-      case _ => log.info("Missing role and/or stream configuration to enable log shipping to central ELK")
+    val stream: Option[String] = extraConfig.getOptional[String]("LoggingStream")
+    stream match {
+      case Some(stream) =>
+        LogConfiguration.shipping(stream, identity)
+      case _ => log.info("Missing stream configuration to enable log shipping to central ELK")
     }
-    
+
     log.info(s"Loaded config $extraConfig")
 
     val combinedConfig: Configuration = extraConfig.withFallback(context.initialConfiguration)

--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,7 +1,8 @@
 import com.amazonaws.regions.Regions
-import conf.{AWS, DynamoConfiguration, FileConfiguration, Identity}
+import conf.{AWS, DynamoConfiguration, FileConfiguration, Identity, LogConfiguration}
+import play.api.Configuration
 import play.api._
-import utils.{Logging, AWSCredentialProviders}
+import utils.{AWSCredentialProviders, Logging}
 
 class AppLoader extends ApplicationLoader with Logging {
   def load(context: ApplicationLoader.Context): Application = {
@@ -29,6 +30,15 @@ class AppLoader extends ApplicationLoader with Logging {
 
     val extraConfig: Configuration = extraConfigs.foldRight(Configuration.empty)(_.configuration(context.environment.mode).withFallback(_))
 
+    val role: Option[String] = extraConfig.getOptional[String]("accounts.LoggingRole")
+    val stream: Option[String] = extraConfig.getOptional[String]("accounts.LoggingStream")
+
+    (role, stream) match {
+      case (Some(role), Some(stream)) =>
+        LogConfiguration.shipping(role, stream, identity)
+      case _ => log.info("Missing role and/or stream configuration to enable log shipping to central ELK")
+    }
+    
     log.info(s"Loaded config $extraConfig")
 
     val combinedConfig: Configuration = extraConfig.withFallback(context.initialConfiguration)

--- a/app/conf/LogConfiguration.scala
+++ b/app/conf/LogConfiguration.scala
@@ -1,0 +1,51 @@
+package conf
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import com.amazonaws.regions.Regions
+import com.gu.logback.appender.kinesis.KinesisAppender
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
+import ch.qos.logback.classic.{Logger => LogbackLogger}
+import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import net.logstash.logback.layout.LogstashLayout
+import play.api.libs.json.Json
+
+object LogConfiguration {
+
+  private def makeCustomFields(config: Identity): String = {
+    Json.toJson(Map(
+      "app" -> config.app,
+      "stack" -> config.stack,
+      "stage" -> config.stage)).toString()
+  }
+
+  private def buildCredentialsProvider(role: String, config: Identity) = {
+    val sessionId = s"${config.app}-session"
+
+    val instanceProvider = InstanceProfileCredentialsProvider.getInstance()
+    val client = AWSSecurityTokenServiceClientBuilder.standard.withCredentials(instanceProvider).build
+    new STSAssumeRoleSessionCredentialsProvider.Builder(role, sessionId).withStsClient(client).build
+  }
+
+  def shipping(role: String, stream: String, config: Identity) = {
+    val bufferSize: Int = 1000
+    val region: Regions = Regions.EU_WEST_1
+    val rootLogger: LogbackLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
+    val context = rootLogger.getLoggerContext
+    val customFields = makeCustomFields(config)
+    val layout = new LogstashLayout
+    layout.setContext(context)
+    layout.setCustomFields(customFields)
+    layout.start()
+
+    val appender = new KinesisAppender[ILoggingEvent]
+    appender.setBufferSize(bufferSize)
+    appender.setRegion(region.getName)
+    appender.setStreamName(stream)
+    appender.setContext(context)
+    appender.setLayout(layout)
+    appender.setRoleToAssumeArn(role)
+    appender.setCredentialsProvider(buildCredentialsProvider(role, config))
+    appender.start()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,9 @@ lazy val root = (project in file("."))
       ws,
       "org.scala-stm" %% "scala-stm" % "0.9.1",
       filters,
-      specs2 % "test"
+      specs2 % "test",
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.4" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+      "com.gu" % "kinesis-logback-appender" % "1.4.4",
     ),
     scalacOptions ++= List(
       "-encoding", "utf8",


### PR DESCRIPTION
Let's enable prism to log to central ELK! Once this PR is merged, we will test by deploying to CODE and will add screenshots here.

An additional piece of work will be to double check all the log lines in prism and make sure we're happy sending them to central ELK.

Cloudformation changes are here: https://github.com/guardian/deploy-tools-platform/pull/249

