### PR TITLE
adds markers to aid debugging of healthcheck fails

### DIFF
--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -6,8 +6,9 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import scala.language.postfixOps
 import play.api.libs.json._
-import utils.Logging
+import utils.{Logging, Marker}
 import play.api.mvc.Call
+
 import scala.concurrent.duration._
 
 trait IndexedItem {
@@ -58,10 +59,12 @@ object Label {
   def apply[T](c: Collector[T], itemCount: Int): Label = Label(c.resource, c.origin, itemCount)
   def apply[T](c: Collector[T], error: Throwable): Label = Label(c.resource, c.origin, 0, error = Some(error))
 }
-case class Label(resourceType: ResourceType, origin:Origin, itemCount:Int, createdAt:DateTime = new DateTime(), error:Option[Throwable] = None) {
+case class Label(resourceType: ResourceType, origin:Origin, itemCount:Int, createdAt:DateTime = new DateTime(), error:Option[Throwable] = None) extends Marker {
   lazy val isError: Boolean = error.isDefined
   lazy val status: String = if (isError) "error" else "success"
   lazy val bestBefore: BestBefore = BestBefore(createdAt, origin.crawlRate(resourceType.name).shelfLife, error = isError)
+
+  override def toMarkerMap: Map[String, Any] = Map("resource" -> resourceType.name, "account" -> origin.account)
 }
 
 case class ResourceType(name: String)

--- a/app/controllers/ApiResult.scala
+++ b/app/controllers/ApiResult.scala
@@ -130,6 +130,8 @@ object ApiResult extends Logging {
         val resources = Set.empty[String]
         val jsonFields = Map.empty[String, String]
         val crawlRate = Map(noSourceContainer.name -> CrawlRate(15 minutes, 1 minutes))
+
+        override def toMarkerMap: Map[String, Any] = jsonFields
       },
       1,
       noSourceContainer.lastUpdated

--- a/app/controllers/OwnerApi.scala
+++ b/app/controllers/OwnerApi.scala
@@ -37,6 +37,8 @@ class OwnerApi(cc: ControllerComponents)(implicit executionContext: ExecutionCon
         val resources = Set("sources")
         val jsonFields = Map.empty[String, String]
         val crawlRate = Map("Owners" -> CrawlRate(30 days, 30 days))
+
+        override def toMarkerMap: Map[String, Any] = jsonFields
       },
       Owners.all.size,
       DateTime.now

--- a/app/utils/Marker.scala
+++ b/app/utils/Marker.scala
@@ -1,0 +1,5 @@
+package utils
+
+trait Marker {
+  def toMarkerMap: Map[String, Any]
+}

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -83,6 +83,8 @@ object ApiSpec extends PlaySpecification with Results {
     def resources: Set[String] = Set("resources")
     def jsonFields: Map[String, String] = Map("key" -> "value")
     def crawlRate: Map[String, CrawlRate] = Map("test" -> CrawlRate(duration, duration))
+
+    override def toMarkerMap: Map[String, Any] = jsonFields
   }
 
 


### PR DESCRIPTION
## What is the problem?
We're currently working on PR #88, which allows prism to crawl all the AWS regions available to it. This work is facing a problem in that prism is unable to pass the loadbalancer health check when trying to crawl 13 or more regions. This means that we can't deploy this work! 

## What is our solution?
In order to help us better understand this problem we have started shipping prism logs to central ELK (PR #90). In particular we're interested to know how long exactly prism takes to pass its healthcheck. 

This PR introduces Markers so that we can analyse the time taken for prism to crawl certain resources and regions. We're hoping to use the graphing features of Kibana to help us analyse this data. 

Here are the markers that we've introduced:

- resource -> this is the name of the resource eg lambda
- account -> the name of the Guardian account eg deployTools
- region -> eg eu-west-1
- duration -> this is the time it takes for the collector to crawl this resources in milliseconds 
- records -> the number of records crawled

_Note that this work branches off of `crawl-all-regions` and we can discuss actions to take before deploying `crawl-all-regions` to PROD._

## How to test
You could set up local ELK logging or just run prism in DEV mode and check the logs in central ELK.

Here's an example of the logs we generated by running prism in DEV mode:

![Screenshot 2020-11-10 at 13 59 33](https://user-images.githubusercontent.com/42121379/98683548-13707580-235d-11eb-8594-a7320037741f.png)
https://logs.gutools.co.uk/s/devx/goto/6569df9a86249c388f8127eab01e7ea9

## How can we measure success?
Success would be the ability to analyse the fields we've created markers for to understand how long each resource/region crawl is taking.
