### PR TITLE
Logs time taken between application start and healthcheck passing successfully for each resource

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -6,7 +6,7 @@ import play.api.{ApplicationLoader, BuiltInComponentsFromContext}
 import play.filters.HttpFiltersComponents
 import play.filters.gzip.GzipFilterComponents
 import router.Routes
-import utils.{Lifecycle, Logging, ScheduledAgent, StopWatch}
+import utils.{Lifecycle, Logging, ScheduledAgent}
 
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -6,7 +6,7 @@ import play.api.{ApplicationLoader, BuiltInComponentsFromContext}
 import play.filters.HttpFiltersComponents
 import play.filters.gzip.GzipFilterComponents
 import router.Routes
-import utils.{Lifecycle, Logging, ScheduledAgent}
+import utils.{Lifecycle, Logging, ScheduledAgent, StopWatch}
 
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -140,7 +140,7 @@ class SourceStatusAgent(actorSystem: ActorSystem, prismRunTimeStopWatch: StopWat
             "sourcesYetToCrawl" -> uninitialisedSources,
             "duration" -> timeSpent,
             "durationType" -> "healthcheck",
-            "percentageCrawled" -> math.floor((newMap.size - uninitialisedSources)/ newMap.size.toFloat * 100)
+            "percentageCrawled" -> math.floor((newMap.size - uninitialisedSources)/ newMap.size.toFloat)
           ).asJava)
           if (uninitialisedSources == 0) {
             initialisedResources += (label.resourceType -> true)

--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -1,19 +1,16 @@
 package agent
 
-import utils.{LifecycleWithoutApp, Logging, Marker, ScheduledAgent, StopWatch}
-
-import scala.concurrent.duration._
-import scala.language.postfixOps
+import akka.actor.ActorSystem
 import akka.agent.Agent
-import org.joda.time.DateTime
-import akka.actor.{ActorSystem, actorRef2Scala}
-import conf.PrismConfiguration
-import controllers.Prism
 import net.logstash.logback.marker.Markers
+import org.joda.time.DateTime
+import utils._
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
 import scala.util.{Failure, Random, Success}
 
 class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], sourceStatusAgent: SourceStatusAgent, lazyStartup:Boolean = true)(actorSystem: ActorSystem) extends CollectorAgentTrait[T] with Logging with Marker with LifecycleWithoutApp {

--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -6,12 +6,15 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import akka.agent.Agent
 import org.joda.time.DateTime
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, actorRef2Scala}
+import conf.PrismConfiguration
+import controllers.Prism
 import net.logstash.logback.marker.Markers
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
-import scala.util.Random
+import scala.util.{Failure, Random, Success}
 
 class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], sourceStatusAgent: SourceStatusAgent, lazyStartup:Boolean = true)(actorSystem: ActorSystem) extends CollectorAgentTrait[T] with Logging with Marker with LifecycleWithoutApp {
 
@@ -43,7 +46,7 @@ class CollectorAgent[T<:IndexedItem](val collectorSet: CollectorSet[T], sourceSt
     sourceStatusAgent.update(datum.label)
     datum.label match {
       case l@Label(product, origin, size, _, None) =>
-        val marker = Markers.appendEntries((origin.toMarkerMap ++ l.toMarkerMap ++ this.toMarkerMap ++ Map("duration" -> timeSpent)).asJava)
+        val marker = Markers.appendEntries((origin.toMarkerMap ++ l.toMarkerMap ++ this.toMarkerMap ++ Map("CrawlDuration" -> timeSpent)).asJava)
         log.info(s"Crawl of ${product.name} from $origin successful (${timeSpent}ms): $size records, ${l.bestBefore}")(marker)
         datum
       case l@Label(product, origin, _, _, Some(error)) =>
@@ -113,12 +116,14 @@ case class SourceStatus(state: Label, error: Option[Label] = None) {
   lazy val latest: Label = error.getOrElse(state)
 }
 
-class SourceStatusAgent(actorSystem: ActorSystem) {
+class SourceStatusAgent(actorSystem: ActorSystem, prismRunTimeStopWatch: StopWatch) extends Logging with Marker {
   implicit private val collectorAgent: ExecutionContext = actorSystem.dispatchers.lookup("collectorAgent")
   val sourceStatusAgent: Agent[Map[(ResourceType, Origin), SourceStatus]] = Agent(Map.empty)
 
+  val initialisedResources: mutable.Map[ResourceType, Boolean] = mutable.Map()
+
   def update(label:Label):Unit = {
-    sourceStatusAgent.send { previousMap =>
+    sourceStatusAgent.alter { previousMap =>
       val key = (label.resourceType, label.origin)
       val previous = previousMap.get(key)
       val next = label match {
@@ -126,6 +131,26 @@ class SourceStatusAgent(actorSystem: ActorSystem) {
         case bad => SourceStatus(previous.map(_.state).getOrElse(bad), Some(bad))
       }
       previousMap + (key -> next)
+    } onComplete {
+      case Success(newMap) =>
+        if (!initialisedResources.getOrElse(label.resourceType, false)) {
+          val timeSpent = prismRunTimeStopWatch.elapsed
+          val uninitialisedSources = newMap.values.count(_.state.status != "success")
+          val marker = Markers.appendEntries(Map(
+            "totalSourcesToCrawl" -> newMap.size,
+            "resource" -> label.resourceType.name,
+            "sourcesYetToCrawl" -> uninitialisedSources,
+            "duration" -> timeSpent,
+            "percentageCrawled" -> math.floor((newMap.size - uninitialisedSources)/ newMap.size.toFloat * 100)
+          ).asJava)
+          if (uninitialisedSources == 0) {
+            initialisedResources += (label.resourceType -> true)
+            log.info(s"Healthcheck passed successfully for ${label.resourceType.name} after ${timeSpent}ms")(marker)
+          } else {
+            log.info(s"$uninitialisedSources out of ${newMap.size} still not healthy after ${timeSpent}ms")(marker)
+          }
+        }
+      case Failure(_) => log.warn(s"failed to update resource ${label.resourceType.name}")
     }
   }
 
@@ -153,4 +178,5 @@ class SourceStatusAgent(actorSystem: ActorSystem) {
     )
     Datum(label, statusList.toSeq)
   }
+  override def toMarkerMap: Map[String, Any] = Map.empty
 }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -3,20 +3,17 @@ package controllers
 import agent._
 import collectors._
 import conf.PrismConfiguration
-import play.api.Logging
-import play.api.mvc._
-import play.api.mvc.{Action, RequestHeader, Result}
-import play.api.libs.json._
-import play.api.libs.json.Json._
 import play.api.http.Status
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.language.postfixOps
+import play.api.libs.json.Json._
+import play.api.libs.json._
+import play.api.mvc.{Action, RequestHeader, Result, _}
 import utils.{Matchable, ResourceFilter}
 
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
 //noinspection TypeAnnotation
-class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: PrismConfiguration)(implicit executionContext: ExecutionContext) extends AbstractController(cc) with Logging {
+class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: PrismConfiguration)(implicit executionContext: ExecutionContext) extends AbstractController(cc) {
     implicit def referenceWrites[T <: IndexedItem](implicit arnLookup:ArnLookup[T], tWrites:Writes[T], request: RequestHeader): Writes[Reference[T]] = (o: Reference[T]) => {
       request.getQueryString("_reference") match {
         case Some("inline") =>
@@ -90,9 +87,9 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
         val notInitialisedSources = sources.data.filter(_.state.status != "success")
         if (notInitialisedSources.isEmpty) Map.empty else Map(sources.label -> notInitialisedSources)
       } reduce { notInitialisedSources =>
-        if (notInitialisedSources.isEmpty)
+        if (notInitialisedSources.isEmpty) {
           Json.obj("healthcheck" -> "initialised")
-        else
+        } else
           throw ApiCallException(Json.obj("healthcheck" -> "not yet initialised", "sources" -> notInitialisedSources.values.headOption), SERVICE_UNAVAILABLE)
       }
     }

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -4,10 +4,12 @@ import agent.{Accounts, CollectorAgent, SourceStatusAgent}
 import akka.actor.ActorSystem
 import collectors._
 import conf.PrismConfiguration
+import utils.StopWatch
 
 // TODO: Maybe we should refactor this to be PrismAgents and to not be in the controllers package?
 class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
-  val sourceStatusAgent = new SourceStatusAgent(actorSystem)
+  val prismRunTimeStopWatch = new StopWatch
+  val sourceStatusAgent = new SourceStatusAgent(actorSystem, prismRunTimeStopWatch)
   val accounts = new Accounts(prismConfiguration)
 
   val lazyStartup: Boolean = prismConfiguration.accounts.lazyStartup


### PR DESCRIPTION
## What is the problem?

The root problem we're trying to solve is to have visibility over which AWS resources we have employed across the Guardian estate. Currently we don't have that, which is a security concern. So PR #88 aims to solve this by making Prism crawl all the 16 AWS regions that it has access to. 

In order to deploy this feature, we need Prism to pass its healthcheck, which it is currently only doing with 12 regions. In order to gain more visibility on how long it's taking Prism to perform the initial crawl of all resources in all regions, we have set up log shipping to central ELK (#90) and added helpful markers so that we can analyse the data returned easily (#91).

The logging added thus far is helpful, but it doesn't tell us how long Prism is taking from application start to the healthcheck passing successfully. This PR solves this problem.

## How have we solved it?

We've added logging that indicates once a Prism instance has passed its healthcheck. The logging tells us how long it takes for each resource to be crawled successfully.

## How has this been tested?

We've deployed this to CODE with 12 regions in config.

### These log lines log out once a resource has passed its healthcheck 
![Screenshot 2020-11-13 at 10 03 45](https://user-images.githubusercontent.com/42121379/99062673-3e480d00-259b-11eb-88a0-f24a07362203.png)
https://logs.gutools.co.uk/s/devx/goto/4080c31029e5294b190a50e7eb7c8f0f

![Screenshot 2020-11-13 at 10 03 55](https://user-images.githubusercontent.com/42121379/99062703-499b3880-259b-11eb-87dd-c9393e6d375e.png)
https://logs.gutools.co.uk/s/devx/goto/4080c31029e5294b190a50e7eb7c8f0f

### This tells us what % of a resource has been crawled
![Screenshot 2020-11-13 at 10 04 22](https://user-images.githubusercontent.com/42121379/99062752-5ddf3580-259b-11eb-8eb1-aad236594507.png)
https://logs.gutools.co.uk/s/devx/goto/283f21942d0ff8c651bf74bb0283acb6

![Screenshot 2020-11-13 at 10 04 42](https://user-images.githubusercontent.com/42121379/99062774-65064380-259b-11eb-8b7c-461e43d79a84.png)
https://logs.gutools.co.uk/s/devx/goto/283f21942d0ff8c651bf74bb0283acb6

### This tells us how long it takes for one resource in one region to be crawled and how many records were crawled
![Screenshot 2020-11-13 at 10 04 03](https://user-images.githubusercontent.com/42121379/99062712-4f911980-259b-11eb-9718-98878c75da93.png)
https://logs.gutools.co.uk/s/devx/goto/0367ed51063b611cf71c1b7dc43bed1e

![Screenshot 2020-11-13 at 10 04 14](https://user-images.githubusercontent.com/42121379/99062739-5881eb00-259b-11eb-8874-7ae907283a41.png)
https://logs.gutools.co.uk/s/devx/goto/0367ed51063b611cf71c1b7dc43bed1e