### PR TITLE
lambda moved onto aws v2

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,8 +1,7 @@
 import com.amazonaws.regions.Regions
 import com.amazonaws.util.EC2MetadataUtils
-import conf.{AWS, DynamoConfiguration, FileConfiguration, Identity, LogConfiguration}
-import play.api.Configuration
-import play.api._
+import conf._
+import play.api.{Configuration, _}
 import utils.{AWSCredentialProviders, Logging}
 
 import scala.util.Try
@@ -48,6 +47,12 @@ class AppLoader extends ApplicationLoader with Logging {
 
     val contextWithConfig = context.copy(initialConfiguration = combinedConfig)
 
-    new AppComponents(contextWithConfig).application
+    try {
+      new AppComponents(contextWithConfig).application
+    } catch {
+      case t: Throwable =>
+        log.error("Unable to initialise prism", t)
+        throw t
+    }
   }
 }

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -86,10 +86,13 @@ case class Credentials(accessKey: Option[String], role: Option[String], profile:
         .roleSessionName("prism")
         .roleArn(r)
         .build()
+      val stsClientV2 = StsClient.builder()
+        .region(regionV2)
+        .build()
       (
         r,
         new STSAssumeRoleSessionCredentialsProvider.Builder(r, "prism").build(),
-        StsAssumeRoleCredentialsProvider.builder().refreshRequest(req).build()
+        StsAssumeRoleCredentialsProvider.builder().stsClient(stsClientV2).refreshRequest(req).build()
       )
     case (_, _, _, Some(p)) =>
       (

--- a/app/conf/AWS.scala
+++ b/app/conf/AWS.scala
@@ -7,6 +7,8 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Filter, DescribeTagsRequest => EC2DescribeTagsRequest}
 import com.amazonaws.util.EC2MetadataUtils
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.core.retry.RetryPolicy
 import utils.Logging
 
 import scala.collection.MapView
@@ -16,6 +18,16 @@ import scala.util.Try
 object AWS extends Logging {
 
   val clientConfig: ClientConfiguration = new ClientConfiguration().withMaxErrorRetry(10)
+
+  val clientConfigV2: ClientOverrideConfiguration = ClientOverrideConfiguration
+    .builder()
+    .retryPolicy(
+      RetryPolicy
+        .builder()
+        .numRetries(10)
+        .build()
+    )
+    .build()
 
   // This is to detect if we are running in AWS or on GC2. The 169.254.169.254
   // thing works on both but this DNS entry seems peculiar to AWS.

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -51,7 +51,7 @@ class PrismConfiguration(configuration: Configuration) extends Logging {
     }
 
     object aws {
-      lazy val regionsToCrawl: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsToCrawl").getOrElse(Seq("eu-west-1")) //.getOrElse(allRegions)
+      lazy val regionsToCrawl: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsToCrawl").getOrElse(allRegions)
       lazy val highPriorityRegions: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsHighPriority").getOrElse(Seq("eu-west-1"))
       lazy val crawlRates = getCrawlRates(highPriorityRegions)
       lazy val defaultOwnerId: Option[String] = configuration.getOptional[String]("accounts.aws.defaultOwnerId")

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -51,7 +51,7 @@ class PrismConfiguration(configuration: Configuration) extends Logging {
     }
 
     object aws {
-      lazy val regionsToCrawl: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsToCrawl").getOrElse(allRegions)
+      lazy val regionsToCrawl: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsToCrawl").getOrElse(Seq("eu-west-1")) //.getOrElse(allRegions)
       lazy val highPriorityRegions: Seq[String] = configuration.getOptional[Seq[String]]("accounts.aws.regionsHighPriority").getOrElse(Seq("eu-west-1"))
       lazy val crawlRates = getCrawlRates(highPriorityRegions)
       lazy val defaultOwnerId: Option[String] = configuration.getOptional[String]("accounts.aws.defaultOwnerId")

--- a/app/utils/AWSCredentialProviders.scala
+++ b/app/utils/AWSCredentialProviders.scala
@@ -1,16 +1,24 @@
 package utils
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.profile.{ProfileCredentialsProvider => ProfileCredentialsProviderV1}
 import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
 
 object AWSCredentialProviders extends Logging {
   def profileCredentialsProvider(profileName: String) = {
     log.info(s"Using $profileName profile credentials")
-    new ProfileCredentialsProvider(profileName)
+    new ProfileCredentialsProviderV1(profileName)
   }
 
+  private val deployToolsProfile = "deployTools"
+
   def deployToolsCredentialsProviderChain: AWSCredentialsProviderChain = new AWSCredentialsProviderChain(
-    profileCredentialsProvider("deployTools"),
+    profileCredentialsProvider(deployToolsProfile),
     new DefaultAWSCredentialsProviderChain()
+  )
+
+  def deployToolsCredentialsProviderChainV2: AwsCredentialsProviderChain = AwsCredentialsProviderChain.of(
+    ProfileCredentialsProviderV2.builder().profileName(deployToolsProfile).build(),
+    DefaultCredentialsProvider.create()
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ resolvers ++= Seq(
 )
 
 val awsVersion = "1.11.887"
+val awsVersionTwo = "2.15.31"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
@@ -39,6 +40,9 @@ lazy val root = (project in file("."))
     buildInfoPackage := "prism",
     libraryDependencies ++= Seq(
       "com.google.code.findbugs" % "jsr305" % "2.0.0",
+      "software.amazon.awssdk" % "lambda" % awsVersionTwo,
+      "software.amazon.awssdk" % "auth" % awsVersionTwo,
+      "software.amazon.awssdk" % "sts" % awsVersionTwo,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-iam" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "lambda" % awsVersionTwo,
       "software.amazon.awssdk" % "auth" % awsVersionTwo,
       "software.amazon.awssdk" % "sts" % awsVersionTwo,
-      "com.beust" % "jcommander" % "1.75", // deal with security vulnerability introduced by aws sdk
+      "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommander
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-iam" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "lambda" % awsVersionTwo,
       "software.amazon.awssdk" % "auth" % awsVersionTwo,
       "software.amazon.awssdk" % "sts" % awsVersionTwo,
+      "com.beust" % "jcommander" % "1.75", // deal with security vulnerability introduced by aws sdk
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-iam" % awsVersion,


### PR DESCRIPTION
### What does this change?
We've moved the Lambda Collector to v2 of the AWS SDK. We've done this to aid prism in crawling all regions (PR #88). Our hypothesis is that if we can move prism onto v2 of the SDK, eventually moving to use of the asynchronous clients, we can speed up Prism's time to pass its healthcheck.

### How to test
We tested this by deploying to CODE and checking that prism is crawling lambdas and completing its lambda healthcheck successfully.
