### PR TITLE
Adds instance and build ids to the logs

### DIFF
--- a/app/conf/LogConfiguration.scala
+++ b/app/conf/LogConfiguration.scala
@@ -1,31 +1,33 @@
 package conf
 
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Logger => LogbackLogger}
 import com.amazonaws.regions.Regions
 import com.gu.logback.appender.kinesis.KinesisAppender
-import org.slf4j.{LoggerFactory, Logger => SLFLogger}
-import ch.qos.logback.classic.{Logger => LogbackLogger}
-import com.amazonaws.auth.{AWSCredentialsProvider, InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.libs.json.Json
 import utils.AWSCredentialProviders
 
 object LogConfiguration {
 
-  private def makeCustomFields(config: Identity): String = {
+  private def makeCustomFields(config: Identity, instanceId: Option[String]): String = {
     Json.toJson(Map(
-      "app" -> config.app,
-      "stack" -> config.stack,
-      "stage" -> config.stage)).toString()
+        "app" -> config.app,
+        "stack" -> config.stack,
+        "stage" -> config.stage,
+        "buildId" -> prism.BuildInfo.buildNumber,
+      )
+      ++ instanceId.map("instanceId" -> _)
+    ).toString()
   }
 
-  def shipping(stream: String, config: Identity) = {
+  def shipping(stream: String, config: Identity, instanceId: Option[String]) = {
     val bufferSize: Int = 1000
     val region: Regions = Regions.EU_WEST_1
     val rootLogger: LogbackLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
     val context = rootLogger.getLoggerContext
-    val customFields = makeCustomFields(config)
+    val customFields = makeCustomFields(config, instanceId)
     val layout = new LogstashLayout
     layout.setContext(context)
     layout.setCustomFields(customFields)

--- a/app/conf/LogConfiguration.scala
+++ b/app/conf/LogConfiguration.scala
@@ -11,23 +11,22 @@ import utils.AWSCredentialProviders
 
 object LogConfiguration {
 
-  private def makeCustomFields(config: Identity, instanceId: Option[String]): String = {
+  private def makeCustomFields(config: Identity, loggingContext: Map[String, String]): String = {
     Json.toJson(Map(
         "app" -> config.app,
         "stack" -> config.stack,
         "stage" -> config.stage,
-        "buildId" -> prism.BuildInfo.buildNumber,
       )
-      ++ instanceId.map("instanceId" -> _)
+      ++ loggingContext
     ).toString()
   }
 
-  def shipping(stream: String, config: Identity, instanceId: Option[String]) = {
+  def shipping(stream: String, config: Identity, loggingContext: Map[String, String]) = {
     val bufferSize: Int = 1000
     val region: Regions = Regions.EU_WEST_1
     val rootLogger: LogbackLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
     val context = rootLogger.getLoggerContext
-    val customFields = makeCustomFields(config, instanceId)
+    val customFields = makeCustomFields(config, loggingContext)
     val layout = new LogstashLayout
     layout.setContext(context)
     layout.setCustomFields(customFields)


### PR DESCRIPTION
Here we add the instance id and build id to prism logs, to aid developer debugging on the project.