### PR TITLE
Bucket Collector to AWS SDK v2

### DIFF
--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -1,8 +1,10 @@
 package collectors
 
 import agent._
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.amazonaws.services.s3.model.{AmazonS3Exception, ListBucketsRequest, Bucket => AWSBucket}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{GetBucketLocationRequest, ListBucketsRequest, S3Exception, Bucket => AWSBucket}
+
+import scala.language.reflectiveCalls
 import conf.AWS
 import controllers.routes
 import org.joda.time.DateTime
@@ -10,10 +12,9 @@ import play.api.mvc.Call
 import utils.Logging
 
 import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
 import scala.util.Try
 import scala.util.control.NonFatal
-import scala.concurrent.duration._
-import scala.language.postfixOps
 
 
 class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](ResourceType("bucket"), accounts) {
@@ -24,15 +25,16 @@ class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](Resour
 
 case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Bucket] with Logging {
 
-  val client: AmazonS3 = AmazonS3ClientBuilder.standard()
-    .withCredentials(origin.credentials.provider)
-    .withRegion(origin.awsRegion)
-    .withClientConfiguration(AWS.clientConfig)
+  val client = S3Client
+    .builder()
+    .credentialsProvider(origin.credentials.providerV2)
+    .region(origin.awsRegionV2)
+    .overrideConfiguration(AWS.clientConfigV2)
     .build()
 
   def crawl: Iterable[Bucket] = {
-    val request = new ListBucketsRequest()
-    client.listBuckets(request).asScala
+    val request = ListBucketsRequest.builder().build()
+    client.listBuckets(request).buckets().asScala
       .flatMap {
         Bucket.fromApiData(_, client)
       }
@@ -43,23 +45,20 @@ object Bucket {
 
   private def arn(bucketName: String) = s"arn:aws:s3:::$bucketName" 
 
-  def fromApiData(bucket: AWSBucket, client: AmazonS3): Option[Bucket] = {
-    val bucketName = bucket.getName
+  def fromApiData(bucket: AWSBucket, client: S3Client): Option[Bucket] = {
+    val bucketName = bucket.name
     try {
-      val bucketRegion = client.getBucketLocation(bucket.getName)
-      if (bucketRegion == client.getRegionName) {
+      // TODO: not sure if we still need the if block that checked the bucket location vs the client's region
+      val bucketRegion = client.getBucketLocation(GetBucketLocationRequest.builder().bucket(bucketName).build()).locationConstraintAsString()
         Some(Bucket(
           arn = arn(bucketName),
           name = bucketName,
           region = bucketRegion,
-          createdTime = Try(new DateTime(bucket.getCreationDate)).toOption
+          createdTime = Try(new DateTime(bucket.creationDate())).toOption
         ))
-      } else {
-        None
-      }
     } catch {
-      case e:AmazonS3Exception if e.getErrorCode == "NoSuchBucket" => None
-      case e:AmazonS3Exception if e.getErrorCode == "AuthorizationHeaderMalformed" => None
+      case e:S3Exception if e.awsErrorDetails.errorCode == "NoSuchBucket" => None
+      case e:S3Exception if e.awsErrorDetails.errorCode == "AuthorizationHeaderMalformed" => None
       case NonFatal(t) =>
         throw new IllegalStateException(s"Failed when building info for bucket $bucketName", t)
     }

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -1,19 +1,18 @@
 package collectors
 
-import agent._
-import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetBucketLocationRequest, ListBucketsRequest, S3Exception, Bucket => AWSBucket}
+import java.time.Instant
 
-import scala.language.reflectiveCalls
+import agent._
 import conf.AWS
 import controllers.routes
-import org.joda.time.DateTime
 import play.api.mvc.Call
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{GetBucketLocationRequest, ListBucketsRequest, S3Exception, Bucket => AWSBucket}
 import utils.Logging
 
 import scala.jdk.CollectionConverters._
-import scala.language.postfixOps
+import scala.language.{postfixOps, reflectiveCalls}
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -55,7 +54,7 @@ object Bucket {
           arn = arn(bucketName),
           name = bucketName,
           region = bucketRegion,
-          createdTime = Try(new DateTime(bucket.creationDate())).toOption
+          createdTime = Try(bucket.creationDate).toOption
         ))
       } else {
         None
@@ -73,7 +72,7 @@ case class Bucket(
   arn: String,
   name: String,
   region: String,
-  createdTime: Option[DateTime]
+  createdTime: Option[Instant]
 ) extends IndexedItem {
   override def callFromArn: (String) => Call = arn => routes.Api.bucket(arn)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "com.google.code.findbugs" % "jsr305" % "2.0.0",
       "software.amazon.awssdk" % "lambda" % awsVersionTwo,
+      "software.amazon.awssdk" % "s3" % awsVersionTwo,
       "software.amazon.awssdk" % "auth" % awsVersionTwo,
       "software.amazon.awssdk" % "sts" % awsVersionTwo,
       "software.amazon.awssdk" % "acm" % awsVersionTwo,


### PR DESCRIPTION
### What does this change?
This continues the work started in PR #95 to move prism to AWS SDK v2

### TODO
1. After deploy, check the logs to see if we're crawling buckets at all. If not, then debug what `Region.toString` vs `GetBucketLocationResponse.locationConstraintAsString()` is in `Bucket.scala:53`, as this could be the culprit.

1. Redo teamcity build after committing change within github ui