### PR TITLE
Add /sources/accounts endpoint.

### DIFF
--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -26,6 +26,8 @@ trait IndexedItemWithStack extends IndexedItem {
   val stack: Option[String] = None
 }
 
+case class AWSAccount(accountNumber: Option[String], accountName: String)
+
 abstract class CollectorSet[T](val resource:ResourceType, accounts: Accounts) extends Logging {
   def lookupCollector:PartialFunction[Origin, Collector[T]]
   def collectorFor(origin:Origin): Option[Collector[T]] = {

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -200,6 +200,19 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
     def mainclassList = summary[Instance](prismDataStore.instanceAgent, i => i.mainclasses.map(Json.toJson(_)), "mainclasses")
     def stackList = summaryFromTwo[Instance, Lambda](prismDataStore.instanceAgent, stackExtractor, prismDataStore.lambdaAgent, stackExtractor, "stacks")(prismConfiguration.stages.ordering)
     def stageList = summaryFromTwo[Instance, Lambda](prismDataStore.instanceAgent, stageExtractor, prismDataStore.lambdaAgent, stageExtractor, "stages")(prismConfiguration.stages.ordering)
+    def instanceAccounts: Action[AnyContent] = Action.async { implicit request =>
+      ApiResult.noSource {
+        val accounts = prismDataStore.instanceAgent.get().map{c =>
+          val accountName = c.label.origin.account
+          val accountNumber = c.label.origin match {
+            case a: AmazonOrigin => a.accountNumber
+            case _ => None
+          }
+          AWSAccount(accountNumber, accountName)
+        }.toList
+        Json.toJson(accounts.distinct)
+      }
+    }
     def regionList = summary[Instance](prismDataStore.instanceAgent, i => Some(Json.toJson(i.region)), "regions")
     def vendorList = summary[Instance](prismDataStore.instanceAgent, i => Some(Json.toJson(i.vendor)), "vendors")
     def appList = summary[Instance](

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -123,6 +123,20 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
       Api.singleItem(prismDataStore.instanceAgent, arn)
     }
 
+    def instanceAccounts: Action[AnyContent] = Action.async { implicit request =>
+      ApiResult.noSource {
+        val accounts = prismDataStore.instanceAgent.get().map { c =>
+          val accountName = c.label.origin.account
+          val accountNumber = c.label.origin match {
+            case a: AmazonOrigin => a.accountNumber
+            case _ => None
+          }
+          AWSAccount(accountNumber, accountName)
+        }.toList.distinct
+        Json.toJson(accounts)
+      }
+    }
+
     def lambdaList = Action.async { implicit request =>
       Api.itemList(prismDataStore.lambdaAgent, "lambdas")
     }
@@ -200,19 +214,6 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
     def mainclassList = summary[Instance](prismDataStore.instanceAgent, i => i.mainclasses.map(Json.toJson(_)), "mainclasses")
     def stackList = summaryFromTwo[Instance, Lambda](prismDataStore.instanceAgent, stackExtractor, prismDataStore.lambdaAgent, stackExtractor, "stacks")(prismConfiguration.stages.ordering)
     def stageList = summaryFromTwo[Instance, Lambda](prismDataStore.instanceAgent, stageExtractor, prismDataStore.lambdaAgent, stageExtractor, "stages")(prismConfiguration.stages.ordering)
-    def instanceAccounts: Action[AnyContent] = Action.async { implicit request =>
-      ApiResult.noSource {
-        val accounts = prismDataStore.instanceAgent.get().map{c =>
-          val accountName = c.label.origin.account
-          val accountNumber = c.label.origin match {
-            case a: AmazonOrigin => a.accountNumber
-            case _ => None
-          }
-          AWSAccount(accountNumber, accountName)
-        }.toList
-        Json.toJson(accounts.distinct)
-      }
-    }
     def regionList = summary[Instance](prismDataStore.instanceAgent, i => Some(Json.toJson(i.region)), "regions")
     def vendorList = summary[Instance](prismDataStore.instanceAgent, i => Some(Json.toJson(i.vendor)), "vendors")
     def appList = summary[Instance](

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -62,6 +62,8 @@ object model {
 
   implicit val loadBalancerWriter: Writes[LoadBalancer] = Json.writes[LoadBalancer]
 
+  implicit val awsAccountWrites = Json.writes[AWSAccount]
+
   implicit val labelWriter:Writes[Label] = (l: Label) => {
     Json.obj(
       "resource" -> l.resourceType.name,

--- a/conf/routes
+++ b/conf/routes
@@ -19,6 +19,7 @@ GET        /instances/regions                 controllers.Api.regionList
 GET        /instances/vendors                 controllers.Api.vendorList
 GET        /instances/roles                   controllers.Api.roleList
 GET        /instances/mainclasses             controllers.Api.mainclassList
+GET        /instances/accounts                controllers.Api.instanceAccounts
 GET        /instances/:arn                    controllers.Api.instance(arn)
 
 GET        /lambdas                           controllers.Api.lambdaList

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,7 @@ GET        /                                  controllers.Application.index
 
 # API V1
 GET        /sources                           controllers.Api.sources
+GET        /sources/accounts                  controllers.Api.sourceAccounts
 GET        /management/healthcheck            controllers.Api.healthCheck
 
 GET        /apps                              controllers.Api.appList
@@ -19,7 +20,6 @@ GET        /instances/regions                 controllers.Api.regionList
 GET        /instances/vendors                 controllers.Api.vendorList
 GET        /instances/roles                   controllers.Api.roleList
 GET        /instances/mainclasses             controllers.Api.mainclassList
-GET        /instances/accounts                controllers.Api.instanceAccounts
 GET        /instances/:arn                    controllers.Api.instance(arn)
 
 GET        /lambdas                           controllers.Api.lambdaList


### PR DESCRIPTION
## What does this change?
Introduces a new endpoint to list aws accounts containing instances indexed by prism. The output looks like this: 
<img width="452" alt="Screenshot 2020-11-24 at 15 59 44" src="https://user-images.githubusercontent.com/3606555/100118806-16e02280-2e6e-11eb-8a7a-c7ceaae7659c.png">


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This is currently on CODE https://prism.code.dev-gutools.co.uk/sources/accounts

## How can we measure success?
We can use this endpoint to e.g. power UI elements that need a list of AWS accounts. It should also be useful for quickly answering the question "what account is 12312312"?
