### PR TITLE
Route 53 Collector to AWS SDK v2

### DIFF
--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -140,10 +140,9 @@ case class AmazonOrigin(account:String, region:String, credentials: Credentials,
   val jsonFields: Map[String, String] = Map("region" -> region, "credentials" -> credentials.id) ++
     accountNumber.map("accountNumber" -> _) ++
     ownerId.map("ownerId" -> _)
-  val awsRegion: Regions = Regions.fromName(region)
   val awsRegionV2: Region = Region.of(region)
 
-  override def toMarkerMap: Map[String, Any] = Map("region" -> awsRegion)
+  override def toMarkerMap: Map[String, Any] = Map("region" -> awsRegionV2.id)
 }
 case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String], crawlRate: Map[String, CrawlRate]) extends Origin with Logging {
   private val classpathHandler = new URLStreamHandler {

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -14,7 +14,7 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Global)) {
+class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
     case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
@@ -24,7 +24,7 @@ case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: Resourc
 
   val client: AmazonIdentityManagement = AmazonIdentityManagementClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
-    .withRegion(origin.awsRegion)
+    .withRegion(origin.awsRegionV2.id)
     .withClientConfiguration(AWS.clientConfig)
     .build()
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "ec2" % awsVersionTwo,
       "software.amazon.awssdk" % "autoscaling" % awsVersionTwo,
       "software.amazon.awssdk" % "elasticloadbalancing" % awsVersionTwo,
+      "software.amazon.awssdk" % "route53" % awsVersionTwo,
       "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommander
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,


### PR DESCRIPTION
## What does this change?
This continues the work started in PR #95 to move prism to AWS SDK v2

