### PR TITLE
ELB Collector to AWS SDK v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "acm" % awsVersionTwo,
       "software.amazon.awssdk" % "ec2" % awsVersionTwo,
       "software.amazon.awssdk" % "autoscaling" % awsVersionTwo,
+      "software.amazon.awssdk" % "elasticloadbalancing" % awsVersionTwo,
       "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommander
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,


### PR DESCRIPTION
### What does this change?
This continues the work started in PR #95 to move prism to AWS SDK v2

