### PR TITLE
Adds explicit JSON writer for Java Time Instant

### DIFF
--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -1,13 +1,15 @@
 package jsonimplicits
 
-import org.joda.time.format.ISODateTimeFormat
-import play.api.libs.json._
-import collectors._
-import play.api.libs.json.JsString
-import agent._
-import play.api.mvc.RequestHeader
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId, ZoneOffset}
+
 import _root_.model.{Owner, SSA}
+import agent._
+import collectors._
 import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.json.{JsString, _}
+import play.api.mvc.RequestHeader
 
 trait RequestWrites[T] {
   def writes(request: RequestHeader): Writes[T]
@@ -25,6 +27,8 @@ object joda {
 
 object model {
   import joda.dateTimeWrites
+  val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX").withZone(ZoneId.from(ZoneOffset.UTC))
+  implicit val instantWrites: Writes[Instant] = Writes.temporalWrites[Instant, DateTimeFormatter](formatter)
 
   implicit val originWriter: Writes[Origin] = (o: Origin) => o.toJson
 


### PR DESCRIPTION
## What does this change?
As part of the AWS SDK v2 upgrade, we changed a number of time types from Java Datetime to Java Instant. This broke Amiable, which was expecting milliseconds. This PR adds those milliseconds back by adding our own JSON writer. We've done this in the case that other Guardian applications may be expecting this.

## How to test
We've already put out a fix for Amiable, but we can double check that Amiable still's working. We can also go through the different prism endpoints and check that the time values are all formatted as expected.
