### PR TITLE
Adds global vs regional concept to collectors

### DIFF
--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -33,8 +33,17 @@ sealed trait AwsRegionType
 case object Global extends AwsRegionType
 case object Regional extends AwsRegionType
 
-/** The awsRegionType specifies whether an AWS collector is global or regional. The AWS_GLOBAL region is required for
- * global services, such as Route 53. */
+/** A CollectorSet knows how to create a set of collectors for a given resource type that typically
+ *  spans multiple accounts, which can be of different underlying platforms. 
+ *  A CollectorSet creates an appropriate set of Collector instances for each account and region.
+ *
+ * @param resourceType the name of the resource that this CollectorSet is responsible for
+ * @param accounts the set of accounts to collect this resource from
+ * @param awsRegionType some resourceTypes in AWS have a single Global instance instead of Regional 
+ * instances. If a CollectorSet processes `AmazonOrigin` origins then you should specify whether the AWS 
+ * collector is global (such as Route53) or regional (such as EC2 instances).
+ * @tparam T the class that represents a collected instance of the resource
+ */
 abstract class CollectorSet[T](val resource:ResourceType, accounts: Accounts, val awsRegionType: Option[AwsRegionType]) extends Logging {
   /** Create a collector for the given origin (this is a partial function because not all collectors support
    *  all types of origin */

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -33,14 +33,14 @@ sealed trait AwsRegionType
 case object Global extends AwsRegionType
 case object Regional extends AwsRegionType
 
-abstract class CollectorSet[T](val resource:ResourceType, accounts: Accounts) extends Logging {
-  /** AWS services are either global or regional. AWS collectors should specify which to ensure that the APIs are used
-   * correctly. */
-  def awsRegionType: Option[AwsRegionType]
+/** The awsRegionType specifies whether an AWS collector is global or regional. The AWS_GLOBAL region is required for
+ * global services, such as Route 53. */
+abstract class CollectorSet[T](val resource:ResourceType, accounts: Accounts, val awsRegionType: Option[AwsRegionType]) extends Logging {
   /** Create a collector for the given origin (this is a partial function because not all collectors support
    *  all types of origin */
   def lookupCollector:PartialFunction[Origin, Collector[T]]
-
+  /** Returns true if the AwsRegionType (Global or Regional) matches the origin's region. This means that we can filter
+   * on this value when we come to create the list of collectors and ensure that Global services crawl AWS_GLOBAL only. */
   def isOriginRegionType(regionType: Option[AwsRegionType])(origin: Origin): Boolean = {
     (origin, regionType) match {
       case (AmazonOrigin(_, region, _, _, _, _, _, _), Some(Global)) if region != Region.AWS_GLOBAL.id => false

--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -37,7 +37,7 @@ case object Regional extends AwsRegionType
  *  spans multiple accounts, which can be of different underlying platforms. 
  *  A CollectorSet creates an appropriate set of Collector instances for each account and region.
  *
- * @param resourceType the name of the resource that this CollectorSet is responsible for
+ * @param resource the name of the resource that this CollectorSet is responsible for
  * @param accounts the set of accounts to collect this resource from
  * @param awsRegionType some resourceTypes in AWS have a single Global instance instead of Regional 
  * instances. If a CollectorSet processes `AmazonOrigin` origins then you should specify whether the AWS 

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -140,10 +140,9 @@ case class AmazonOrigin(account:String, region:String, credentials: Credentials,
   val jsonFields: Map[String, String] = Map("region" -> region, "credentials" -> credentials.id) ++
     accountNumber.map("accountNumber" -> _) ++
     ownerId.map("ownerId" -> _)
-  val awsRegion: Regions = Regions.fromName(region)
   val awsRegionV2: Region = Region.of(region)
 
-  override def toMarkerMap: Map[String, Any] = Map("region" -> awsRegion)
+  override def toMarkerMap: Map[String, Any] = Map("region" -> awsRegionV2.id)
 }
 case class JsonOrigin(vendor:String, account:String, url:String, resources:Set[String], crawlRate: Map[String, CrawlRate]) extends Origin with Logging {
   private val classpathHandler = new URLStreamHandler {

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -18,6 +18,8 @@ class AmazonCertificateCollectorSet(accounts: Accounts) extends CollectorSet[Acm
   val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
     case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSAcmCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[AcmCertificate] with Logging {

--- a/app/collectors/acmCertificates.scala
+++ b/app/collectors/acmCertificates.scala
@@ -14,12 +14,10 @@ import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
 
-class AmazonCertificateCollectorSet(accounts: Accounts) extends CollectorSet[AcmCertificate](ResourceType("acmCertificates"), accounts) {
+class AmazonCertificateCollectorSet(accounts: Accounts) extends CollectorSet[AcmCertificate](ResourceType("acmCertificates"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[AcmCertificate]] = {
     case amazon: AmazonOrigin => AWSAcmCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSAcmCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[AcmCertificate] with Logging {

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -21,6 +21,8 @@ class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](Resour
   val lookupCollector: PartialFunction[Origin, Collector[Bucket]] = {
     case amazon: AmazonOrigin => AWSBucketCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Bucket] with Logging {

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -17,12 +17,10 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 
-class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](ResourceType("bucket"), accounts) {
+class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](ResourceType("bucket"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[Bucket]] = {
     case amazon: AmazonOrigin => AWSBucketCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Bucket] with Logging {

--- a/app/collectors/data.scala
+++ b/app/collectors/data.scala
@@ -13,6 +13,8 @@ class DataCollectorSet(accounts: Accounts) extends CollectorSet[Data](ResourceTy
   def lookupCollector: PartialFunction[Origin, Collector[Data]] = {
     case json:JsonOrigin => JsonDataCollector(json, resource, json.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class JsonDataCollector(origin:JsonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends JsonCollector[Data] {

--- a/app/collectors/data.scala
+++ b/app/collectors/data.scala
@@ -9,12 +9,10 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.matching.Regex
 
-class DataCollectorSet(accounts: Accounts) extends CollectorSet[Data](ResourceType("data"), accounts) {
+class DataCollectorSet(accounts: Accounts) extends CollectorSet[Data](ResourceType("data"), accounts, None) {
   def lookupCollector: PartialFunction[Origin, Collector[Data]] = {
     case json:JsonOrigin => JsonDataCollector(json, resource, json.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class JsonDataCollector(origin:JsonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends JsonCollector[Data] {

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -17,6 +17,8 @@ class ImageCollectorSet(accounts:Accounts) extends CollectorSet[Image](ResourceT
   val lookupCollector: PartialFunction[Origin, Collector[Image]] = {
     case amazon:AmazonOrigin => AWSImageCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType, crawlRate: CrawlRate) extends Collector[Image] with Logging {

--- a/app/collectors/image.scala
+++ b/app/collectors/image.scala
@@ -13,12 +13,10 @@ import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.Try
 
-class ImageCollectorSet(accounts:Accounts) extends CollectorSet[Image](ResourceType("images"), accounts) {
+class ImageCollectorSet(accounts:Accounts) extends CollectorSet[Image](ResourceType("images"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[Image]] = {
     case amazon:AmazonOrigin => AWSImageCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSImageCollector(origin:AmazonOrigin, resource:ResourceType, crawlRate: CrawlRate) extends Collector[Image] with Logging {

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -19,6 +19,8 @@ class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSe
   val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
     case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource, amazon.crawlRate(resource.name), prism)
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSInstanceCollector(origin:AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate, prism: Prism) extends Collector[Instance] with Logging {

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -15,12 +15,10 @@ import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.matching.Regex
 
-class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSet[Instance](ResourceType("instance"), accounts) {
+class InstanceCollectorSet(accounts: Accounts, prism: Prism) extends CollectorSet[Instance](ResourceType("instance"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[Instance]] = {
     case amazon:AmazonOrigin => AWSInstanceCollector(amazon, resource, amazon.crawlRate(resource.name), prism)
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSInstanceCollector(origin:AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate, prism: Prism) extends Collector[Instance] with Logging {

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -11,11 +11,10 @@ import utils.Logging
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
-class LambdaCollectorSet(accounts: Accounts) extends CollectorSet[Lambda](ResourceType("lambda"), accounts) {
+class LambdaCollectorSet(accounts: Accounts) extends CollectorSet[Lambda](ResourceType("lambda"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[Lambda]] = {
     case amazon: AmazonOrigin => AWSLambdaCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Lambda] with Logging {

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -15,6 +15,7 @@ class LambdaCollectorSet(accounts: Accounts) extends CollectorSet[Lambda](Resour
   val lookupCollector: PartialFunction[Origin, Collector[Lambda]] = {
     case amazon: AmazonOrigin => AWSLambdaCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Lambda] with Logging {

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -14,11 +14,10 @@ import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.Try
 
-class LaunchConfigurationCollectorSet(accounts: Accounts) extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations"), accounts) {
+class LaunchConfigurationCollectorSet(accounts: Accounts) extends CollectorSet[LaunchConfiguration](ResourceType("launch-configurations"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
     case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[LaunchConfiguration] with Logging {

--- a/app/collectors/launchConfigurations.scala
+++ b/app/collectors/launchConfigurations.scala
@@ -18,6 +18,7 @@ class LaunchConfigurationCollectorSet(accounts: Accounts) extends CollectorSet[L
   val lookupCollector: PartialFunction[Origin, Collector[LaunchConfiguration]] = {
     case amazon: AmazonOrigin => AWSLaunchConfigurationCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSLaunchConfigurationCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[LaunchConfiguration] with Logging {

--- a/app/collectors/loadBalancers.scala
+++ b/app/collectors/loadBalancers.scala
@@ -15,6 +15,8 @@ class LoadBalancerCollectorSet(accounts: Accounts) extends CollectorSet[LoadBala
   val lookupCollector: PartialFunction[Origin, Collector[LoadBalancer]] = {
     case amazon: AmazonOrigin => LoadBalancerCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class LoadBalancerCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[LoadBalancer] with Logging {

--- a/app/collectors/loadBalancers.scala
+++ b/app/collectors/loadBalancers.scala
@@ -11,12 +11,10 @@ import utils.Logging
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
-class LoadBalancerCollectorSet(accounts: Accounts) extends CollectorSet[LoadBalancer](ResourceType("loadBalancers"), accounts) {
+class LoadBalancerCollectorSet(accounts: Accounts) extends CollectorSet[LoadBalancer](ResourceType("loadBalancers"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[LoadBalancer]] = {
     case amazon: AmazonOrigin => LoadBalancerCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class LoadBalancerCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[LoadBalancer] with Logging {

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -17,6 +17,7 @@ class ReservationCollectorSet(accounts: Accounts) extends CollectorSet[Reservati
   val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
     case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Reservation] with Logging {

--- a/app/collectors/reservation.scala
+++ b/app/collectors/reservation.scala
@@ -13,11 +13,10 @@ import utils.Logging
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
-class ReservationCollectorSet(accounts: Accounts) extends CollectorSet[Reservation](ResourceType("reservation"), accounts) {
+class ReservationCollectorSet(accounts: Accounts) extends CollectorSet[Reservation](ResourceType("reservation"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[Reservation]] = {
     case amazon: AmazonOrigin => AWSReservationCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSReservationCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Reservation] with Logging {

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -10,12 +10,10 @@ import software.amazon.awssdk.services.ec2.model.{DescribeSecurityGroupsRequest,
 import scala.jdk.CollectionConverters._
 import scala.language.{existentials, postfixOps}
 
-class SecurityGroupCollectorSet(accounts: Accounts, prismController: Prism) extends CollectorSet[SecurityGroup](ResourceType("security-group"), accounts) {
+class SecurityGroupCollectorSet(accounts: Accounts, prismController: Prism) extends CollectorSet[SecurityGroup](ResourceType("security-group"), accounts, Some(Regional)) {
   def lookupCollector: PartialFunction[Origin, Collector[SecurityGroup]] = {
     case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource, prismController, aws.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType, prismController: Prism, crawlRate: CrawlRate)

--- a/app/collectors/securityGroup.scala
+++ b/app/collectors/securityGroup.scala
@@ -14,6 +14,8 @@ class SecurityGroupCollectorSet(accounts: Accounts, prismController: Prism) exte
   def lookupCollector: PartialFunction[Origin, Collector[SecurityGroup]] = {
     case aws:AmazonOrigin => AWSSecurityGroupCollector(aws, resource, prismController, aws.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Regional)
 }
 
 case class AWSSecurityGroupCollector(origin:AmazonOrigin, resource:ResourceType, prismController: Prism, crawlRate: CrawlRate)

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -14,7 +14,7 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Global)) {
+class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Regional)) {
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
     case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
@@ -24,7 +24,7 @@ case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: Resourc
 
   val client: AmazonIdentityManagement = AmazonIdentityManagementClientBuilder.standard()
     .withCredentials(origin.credentials.provider)
-    .withRegion(origin.awsRegion)
+    .withRegion(origin.awsRegionV2.id)
     .withClientConfiguration(AWS.clientConfig)
     .build()
 

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -14,12 +14,10 @@ import scala.util.Try
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts) {
+class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Global)) {
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
     case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Global)
 }
 
 case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[ServerCertificate] with Logging {

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -1,20 +1,20 @@
 package collectors
 
+import java.time.Instant
+
 import agent._
-import com.amazonaws.services.identitymanagement.{AmazonIdentityManagement, AmazonIdentityManagementClientBuilder}
-import com.amazonaws.services.identitymanagement.model.{ListServerCertificatesRequest, ServerCertificateMetadata}
 import conf.AWS
 import controllers.routes
-import org.joda.time.{DateTime, Duration}
 import play.api.mvc.Call
-import utils.{Logging, PaginatedAWSRequest}
+import software.amazon.awssdk.services.iam.IamClient
+import software.amazon.awssdk.services.iam.model.{ListServerCertificatesRequest, ServerCertificateMetadata}
+import utils.Logging
 
-import scala.collection.JavaConverters._
-import scala.util.Try
-import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
+import scala.util.Try
 
-class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Regional)) {
+class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[ServerCertificate](ResourceType("server-certificates"), accounts, Some(Global)) {
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
     case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
@@ -22,24 +22,28 @@ class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[Ser
 
 case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[ServerCertificate] with Logging {
 
-  val client: AmazonIdentityManagement = AmazonIdentityManagementClientBuilder.standard()
-    .withCredentials(origin.credentials.provider)
-    .withRegion(origin.awsRegionV2.id)
-    .withClientConfiguration(AWS.clientConfig)
+  val client: IamClient = IamClient
+    .builder()
+    .credentialsProvider(origin.credentials.providerV2)
+    .region(origin.awsRegionV2)
+    .overrideConfiguration(AWS.clientConfigV2)
     .build()
 
-  def crawl: Iterable[ServerCertificate] =
-    PaginatedAWSRequest.run(client.listServerCertificates)(new ListServerCertificatesRequest()).map(ServerCertificate.fromApiData(_, origin))
+  def crawl: Iterable[ServerCertificate] = {
+    client.listServerCertificatesPaginator(ListServerCertificatesRequest.builder.build).serverCertificateMetadataList.asScala.map(
+      ServerCertificate.fromApiData(_, origin)
+    )
+  }
 }
 
 object ServerCertificate {
   def fromApiData(metadata: ServerCertificateMetadata, origin: AmazonOrigin): ServerCertificate = ServerCertificate(
-    arn = metadata.getArn,
-    id = metadata.getServerCertificateId,
-    name = metadata.getServerCertificateName,
-    path = metadata.getPath,
-    uploadedAt = Try(new DateTime(metadata.getUploadDate)).toOption,
-    expiryDate = Try(new DateTime(metadata.getExpiration)).toOption
+    arn = metadata.arn,
+    id = metadata.serverCertificateId,
+    name = metadata.serverCertificateName,
+    path = metadata.path,
+    uploadedAt = Try(metadata.uploadDate).toOption,
+    expiryDate = Try(metadata.expiration).toOption
   )
 }
 
@@ -48,8 +52,8 @@ case class ServerCertificate(
   id: String,
   name: String,
   path: String,
-  uploadedAt: Option[DateTime],
-  expiryDate: Option[DateTime]
+  uploadedAt: Option[Instant],
+  expiryDate: Option[Instant]
 ) extends IndexedItem {
   def callFromArn: (String) => Call = arn => routes.Api.serverCertificate(arn)
 }

--- a/app/collectors/serverCertificates.scala
+++ b/app/collectors/serverCertificates.scala
@@ -18,6 +18,8 @@ class ServerCertificateCollectorSet(accounts: Accounts) extends CollectorSet[Ser
   val lookupCollector: PartialFunction[Origin, Collector[ServerCertificate]] = {
     case amazon: AmazonOrigin => AWSServerCertificateCollector(amazon, resource, amazon.crawlRate(resource.name))
   }
+
+  override def awsRegionType: Option[AwsRegionType] = Some(Global)
 }
 
 case class AWSServerCertificateCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[ServerCertificate] with Logging {

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -15,7 +15,7 @@ import scala.language.postfixOps
 
 class Route53ZoneCollectorSet(accounts: Accounts) extends CollectorSet[Route53Zone](ResourceType("route53Zones"), accounts) {
 
-  override def awsRegionType: AwsRegionType = Some(Global)
+  override def awsRegionType: Option[AwsRegionType] = Some(Global)
 
   val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
     case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource, amazon.crawlRate(resource.name))

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -6,6 +6,7 @@ import com.amazonaws.services.route53.model.{HostedZone, ListHostedZonesRequest,
 import conf.AWS
 import controllers.routes
 import play.api.mvc.Call
+import software.amazon.awssdk.regions.Region
 import utils.{Logging, PaginatedAWSRequest}
 
 import scala.jdk.CollectionConverters._
@@ -13,6 +14,9 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class Route53ZoneCollectorSet(accounts: Accounts) extends CollectorSet[Route53Zone](ResourceType("route53Zones"), accounts) {
+
+  override def awsRegionType: AwsRegionType = Some(Global)
+
   val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
     case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource, amazon.crawlRate(resource.name))
   }

--- a/app/collectors/zone.scala
+++ b/app/collectors/zone.scala
@@ -13,9 +13,7 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class Route53ZoneCollectorSet(accounts: Accounts) extends CollectorSet[Route53Zone](ResourceType("route53Zones"), accounts) {
-
-  override def awsRegionType: Option[AwsRegionType] = Some(Global)
+class Route53ZoneCollectorSet(accounts: Accounts) extends CollectorSet[Route53Zone](ResourceType("route53Zones"), accounts, Some(Global)) {
 
   val lookupCollector: PartialFunction[Origin, Collector[Route53Zone]] = {
     case amazon: AmazonOrigin => Route53ZoneCollector(amazon, resource, amazon.crawlRate(resource.name))

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "autoscaling" % awsVersionTwo,
       "software.amazon.awssdk" % "elasticloadbalancing" % awsVersionTwo,
       "software.amazon.awssdk" % "route53" % awsVersionTwo,
+      "software.amazon.awssdk" % "iam" % awsVersionTwo,
       "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommander
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "ec2" % awsVersionTwo,
       "software.amazon.awssdk" % "autoscaling" % awsVersionTwo,
       "software.amazon.awssdk" % "elasticloadbalancing" % awsVersionTwo,
+      "software.amazon.awssdk" % "route53" % awsVersionTwo,
       "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommander
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,


### PR DESCRIPTION
## What does this change?
The AWS SDK 2 introduces the idea of a global region for certain services. For example, Route 53 (Amazon's DNS service). Here, we add this concept to Prism's collectors which can now be Global or Regional. This change means that we can complete the migration process to sdk 2. 

## How can we measure success?
No more error messages when we deploy PRs #105 and #103. 
