### PR TITLE
makes s3 collector global

### DIFF
--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -48,11 +48,11 @@ object Bucket {
   def fromApiData(bucket: AWSBucket, client: S3Client): Option[Bucket] = {
     val bucketName = bucket.name
     try {
-      val bucketRegion = client.getBucketLocation(GetBucketLocationRequest.builder.bucket(bucketName).build).locationConstraintAsString
+      val bucketRegion = Option(client.getBucketLocation(GetBucketLocationRequest.builder.bucket(bucketName).build).locationConstraintAsString)
       Some(Bucket(
         arn = arn(bucketName),
         name = bucketName,
-        region = bucketRegion,
+        region = bucketRegion.getOrElse(Region.US_EAST_1.id),
         createdTime = Try(bucket.creationDate).toOption
       ))
     } catch {

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -28,7 +28,7 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
   // https://stackoverflow.com/questions/46769493/how-enable-force-global-bucket-access-in-aws-s3-sdk-java-2-0
   val s3Configuration = S3Configuration.builder.useArnRegionEnabled(true).build
 
-  // The region of the S3 Client is hardcoded to EU-WEST-1, because AWS-Global does not work with S3.
+  // The region of the S3 Client is hardcoded to EU-WEST-1, because AWS-Global and US-EAST-1 do not return all buckets.
   // We decided to hardcode this here, instead of creating another enum for simplicity 
   val client = S3Client
     .builder
@@ -38,8 +38,8 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
     .serviceConfiguration(s3Configuration)
     .build
 
-  // This second S3 client, with a region of US-EAST-1, gives us the correct createdTime value as documented here:
-  // https://stackoverflow.com/questions/54353373/getting-incorrect-creation-dates-using-aws-s3
+  // This second S3 client, with a region of US-EAST-1, gives us the correct createdTime value unlike the other regions,
+  // as documented here: https://stackoverflow.com/questions/54353373/getting-incorrect-creation-dates-using-aws-s3
   val clientForCorrectCreatedTime = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -30,7 +30,7 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
   val client = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)
-    .region(Region.US_EAST_1)
+    .region(Region.EU_WEST_1)
     .overrideConfiguration(AWS.clientConfig)
     .serviceConfiguration(s3Configuration)
     .build

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -7,7 +7,7 @@ import conf.AWS
 import controllers.routes
 import play.api.mvc.Call
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.{S3Client, S3Configuration}
 import software.amazon.awssdk.services.s3.model.{GetBucketLocationRequest, ListBucketsRequest, S3Exception, Bucket => AWSBucket}
 import utils.Logging
 
@@ -25,11 +25,14 @@ class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](Resour
 
 case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Bucket] with Logging {
 
+  val s3Configuration = S3Configuration.builder.useArnRegionEnabled(true).build
+
   val client = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)
-    .region(Region.US_EAST_1)
+    .region(origin.awsRegionV2)
     .overrideConfiguration(AWS.clientConfig)
+    .serviceConfiguration(s3Configuration)
     .build
 
   def crawl: Iterable[Bucket] = {

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -26,6 +26,8 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
 
   val s3Configuration = S3Configuration.builder.useArnRegionEnabled(true).build
 
+  // We have hardcoded the region of the S3 Client, so that we can receive data on S3 buckets in all AWS regions
+  // https://stackoverflow.com/questions/46769493/how-enable-force-global-bucket-access-in-aws-s3-sdk-java-2-0 
   val client = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -52,7 +52,11 @@ object Bucket extends Logging {
   def fromApiData(bucket: AWSBucket, client: S3Client, origin: AmazonOrigin): Bucket = {
     val bucketName = bucket.name
     val bucketRegion = try {
-      Option(client.getBucketLocation(GetBucketLocationRequest.builder.bucket(bucketName).build).locationConstraintAsString).orElse(Some(Region.US_EAST_1.id))
+      Option(
+        client.getBucketLocation(GetBucketLocationRequest.builder.bucket(bucketName).build).locationConstraintAsString
+      )
+        .filterNot(region => "" == region)
+        .orElse(Some(Region.US_EAST_1.id))
     } catch {
       case e:S3Exception if e.awsErrorDetails.errorCode == "NoSuchBucket" =>
         log.info(s"NoSuchBucket for $bucketName in account ${origin.account}", e)

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -38,7 +38,7 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
     .serviceConfiguration(s3Configuration)
     .build
 
-  // We need to create a second S3 client to get the correct createdTime as documented here:
+  // This second S3 client, with a region of US-EAST-1, gives us the correct createdTime value as documented here:
   // https://stackoverflow.com/questions/54353373/getting-incorrect-creation-dates-using-aws-s3
   val clientForCorrectCreatedTime = S3Client
     .builder

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -95,6 +95,7 @@ object Bucket extends Logging {
 case class Bucket(
   arn: String,
   name: String,
+  //TODO - check we want to keep the region field given S3 is a pseudo global service?
   region: Option[String],
   createdTime: Instant
 ) extends IndexedItem {

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -24,10 +24,12 @@ class BucketCollectorSet(accounts: Accounts) extends CollectorSet[Bucket](Resour
 
 case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Bucket] with Logging {
 
+  // The `useArnRegionEnabled` flag enables us to receive data on buckets in all available AWS regions
+  // https://stackoverflow.com/questions/46769493/how-enable-force-global-bucket-access-in-aws-s3-sdk-java-2-0
   val s3Configuration = S3Configuration.builder.useArnRegionEnabled(true).build
 
-  // We have hardcoded the region of the S3 Client, so that we can receive data on S3 buckets in all AWS regions
-  // https://stackoverflow.com/questions/46769493/how-enable-force-global-bucket-access-in-aws-s3-sdk-java-2-0 
+  // The region of the S3 Client is hardcoded to EU-WEST-1, because AWS-Global does not work with S3.
+  // We decided to hardcode this here, instead of creating another enum for simplicity 
   val client = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -28,7 +28,7 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
   val client = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)
-    .region(origin.awsRegionV2)
+    .region(Region.US_EAST_1)
     .overrideConfiguration(AWS.clientConfig)
     .build
 

--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -30,7 +30,7 @@ case class AWSBucketCollector(origin: AmazonOrigin, resource: ResourceType, craw
   val client = S3Client
     .builder
     .credentialsProvider(origin.credentials.provider)
-    .region(origin.awsRegionV2)
+    .region(Region.US_EAST_1)
     .overrideConfiguration(AWS.clientConfig)
     .serviceConfiguration(s3Configuration)
     .build


### PR DESCRIPTION
## The problem
- we want Prism to crawl more regions (other than the current eu-west-1 and us-east-1) so that we have more visibility over our aws infrastructure. This is important for security reasons. (See more here: PR #88)
- it's hard for Prism to crawl all the aws regions (it's a lot of requests to make to AWS, which takes a long time, which means that prism is failing to pass its healthcheck), so we decided to minimise the number of regions for prism to crawl. We're doing this by shutting down regions that Guardian accounts are able to create new services in (eg https://github.com/guardian/service-control-policies/pull/3) 
-  **The problem is that we have lots of S3 buckets across many different regions** (see the results of a crawl done in November of [all aws regions](https://docs.google.com/spreadsheets/d/1xn9Yr-3_1yWG2qvsHrdXviy6oevGO7gJVt0WCFFQWCg/edit?usp=sharing)). This is preventing us from shutting down access to these regions. 

## The solution
The good news is that AWS's S3 service is special ✨ in that S3 is a kind of pseudo global service. You'll notice when you go into the aws console, that you are unable to select a region for S3, that's because AWS offer resources in S3 globally. 

**Therefore, we don't need to crawl each region to access all of our S3 buckets, we only need to crawl one.** This is fantastic news for us, because it means that we can get access to all our S3 buckets by just crawling `eu-west-1`.💪🏽👏🏽🥳

The advantage of this, to reiterate, is that we can shut down even more regions using our beloved service control policies (https://github.com/guardian/service-control-policies 💝), which means that prism has even fewer regions to crawl.

## How we've tested this
We tested this by deploying to CODE and running `$ curl -s  https://prism.code.dev-gutools.co.uk/buckets | jq .data.buckets[].region | sort | uniq -c | sort -nr` which gives:

```
1114 "eu-west-1"
 117 "EU"
  74 "us-east-1"
  18 "ap-southeast-2"
  12 "us-west-2"
  11 "us-west-1"
   8 "eu-west-2"
   4 "us-east-2"
   4 "eu-central-1"
   1 "eu-west-3"
```

Running the same bash command on current PROD results in the following result `1114 "eu-west-1"`. 

Not only does this change mean that we are able to get information on S3 buckets in all regions by crawling just one, it also means that we have correcting the functionality of our S3 collector, which was previously only returning buckets in `eu-west-1`.💪🏽

## We fixed the createdTime field too - but we had to crawl one extra region
We noticed that we were receiving incorrect creation dates for the S3 buckets, which was introduced prior to this PR and is a known S3 bug. 

To mitigate this, we created another client whose region is set to `us-east-1`, so that we can receive the correct `creationDate` as per this [Stackoverflow post](https://stackoverflow.com/questions/54353373/getting-incorrect-creation-dates-using-aws-s3). 

We tested this change after deploying to CODE with the following bash commands:

_In PROD the createdTime is broken with most of the buckets shown as being created in 2020, which is wrong. This is caused by the region of the S3 Client being set to anything other than `us-east-1`_ 😔
```
$ curl -s https://prism.gutools.co.uk/buckets | jq .data.buckets[].createdTime | sort | cut -d- -f1 | uniq -c
 101 "2019
1013 "2020
```

_In CODE we see a full range of created time dates of the buckets_ 🎉 😃 🎉
```
$ curl -s https://prism.code.dev-gutools.co.uk/buckets | jq .data.buckets[].createdTime | sort | cut -d- -f1 | uniq -c
   2 "2009
  34 "2012
  36 "2013
  86 "2014
 167 "2015
 185 "2016
 132 "2017
 216 "2018
 342 "2019
 163 "2020
```
