### PR TITLE
Make the shelf life for the source agent infinite

### DIFF
--- a/test/CollectorModelSpec.scala
+++ b/test/CollectorModelSpec.scala
@@ -20,6 +20,10 @@ class CollectorModelSpec extends Specification {
       val bb = BestBefore(new DateTime, 30 seconds, error = false)
       bb.isStale should beFalse
     }
+    "say it is not stale if shelf life is infinite" in {
+      val bb = BestBefore(new DateTime, Duration.Inf, error = false)
+      bb.isStale should beFalse
+    }
   }
 
 }


### PR DESCRIPTION
## What does this change?
The `/sources` endpoint in Prism returns metadata about all of the active collectors. This comes from a combination of configuration read at startup and status data from the individual collectors held in application memory. Unlike a normal collector, it can by definition never be stale. Unfortunately the way that staleness is calculated means that this was stale under some configurations.

This PR modifies the `CrawlRate` object so that the `shelfLife` and `refreshPeriod` fields are `Duration` rather than `FiniteDuration`. This allows them to be set to Duration.Inf and Duration.Undefined in the case of `source` where it cannot become stale and doesn't refresh. 

Note that:
 - If a normal collector is somehow configured with a refresh period that isn't finite we now log a warning and don't schedule collections
 - We also now set the update time of sources to be the boot time of the application.

## How to test
When a configuration that contains low priority regions is deployed, sources no longer becomes stale and AMIgo continues to operate when consuming Prism's sources endpoint.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Low priortity regions can be configured.