### PR TITLE
Add VPCs to Prism

### DIFF
--- a/app/collectors/vpc.scala
+++ b/app/collectors/vpc.scala
@@ -46,15 +46,6 @@ object Vpc {
     accountId = vpc.ownerId,
     state = vpc.stateAsString,
     cidrBlock = vpc.cidrBlock,
-    cidrBlockAssociationSet = vpc.cidrBlockAssociationSet.asScala.toList.map{ c =>
-      CidrBlockAssociation(c.cidrBlock, c.associationId, c.cidrBlockState.stateAsString)
-    },
-    dhcpOptionsId = vpc.dhcpOptionsId,
-    instanceTenancy = vpc.instanceTenancyAsString,
-    ipv6CidrBlockAssociationSet = vpc.ipv6CidrBlockAssociationSet.asScala.toList.map{ c =>
-      Ipv6CidrBlockAssociation(c.associationId, c.ipv6CidrBlock, c.ipv6CidrBlockState.stateAsString, c.networkBorderGroup, c.ipv6Pool)
-    },
-    isDefault = vpc.isDefault,
     subnets = subnets.toList.map{s =>
       Subnet(
         s.subnetArn,

--- a/app/collectors/vpc.scala
+++ b/app/collectors/vpc.scala
@@ -1,0 +1,94 @@
+package collectors
+
+import agent._
+import conf.AWS
+import controllers.routes
+import play.api.mvc.Call
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.{DescribeSubnetsRequest, DescribeVpcsRequest, Filter, Subnet => AwsSubnet, Vpc => AwsVpc}
+import utils.Logging
+
+import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
+
+class VpcCollectorSet(accounts: Accounts) extends CollectorSet[Vpc](ResourceType("Vpc"), accounts, Some(Regional)) {
+  val lookupCollector: PartialFunction[Origin, Collector[Vpc]] = {
+    case amazon:AmazonOrigin => AWSVpcCollector(amazon, resource, amazon.crawlRate(resource.name))
+  }
+}
+
+case class AWSVpcCollector(origin:AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[Vpc] with Logging {
+
+  val client: Ec2Client = Ec2Client
+    .builder
+    .credentialsProvider(origin.credentials.provider)
+    .region(origin.awsRegionV2)
+    .overrideConfiguration(AWS.clientConfig)
+    .build
+
+  def getSubnets(vpcId: String) = {
+    val subnetsRequest = DescribeSubnetsRequest.builder.filters(Filter.builder.name("vpc-id").values(vpcId).build).build
+    client.describeSubnetsPaginator(subnetsRequest).subnets.asScala
+  }
+
+  def crawl:Iterable[Vpc] =
+    client.describeVpcsPaginator(DescribeVpcsRequest.builder.build).vpcs.asScala.map { vpc =>
+      Vpc.fromApiData(vpc, getSubnets(vpc.vpcId), origin)
+    }
+}
+
+object Vpc {
+  def arn(region: String, account: String, vpcId: String) = s"arn:aws:ec2:$region:$account:vpc/$vpcId"
+
+  def fromApiData(vpc: AwsVpc, subnets: Iterable[AwsSubnet], origin: AmazonOrigin): Vpc = Vpc(
+    arn = arn(origin.region, origin.account, vpc.vpcId),
+    vpcId = vpc.vpcId,
+    accountId = vpc.ownerId,
+    state = vpc.stateAsString,
+    cidrBlock = vpc.cidrBlock,
+    cidrBlockAssociationSet = vpc.cidrBlockAssociationSet.asScala.toList.map{ c =>
+      CidrBlockAssociation(c.cidrBlock, c.associationId, c.cidrBlockState.stateAsString)
+    },
+    dhcpOptionsId = vpc.dhcpOptionsId,
+    instanceTenancy = vpc.instanceTenancyAsString,
+    ipv6CidrBlockAssociationSet = vpc.ipv6CidrBlockAssociationSet.asScala.toList.map{ c =>
+      Ipv6CidrBlockAssociation(c.associationId, c.ipv6CidrBlock, c.ipv6CidrBlockState.stateAsString, c.networkBorderGroup, c.ipv6Pool)
+    },
+    isDefault = vpc.isDefault,
+    subnets = subnets.toList.map{s =>
+      Subnet(
+        s.subnetArn,
+        s.availabilityZone,
+        s.cidrBlock,
+        s.stateAsString,
+        s.subnetId,
+        s.ownerId,
+        s.tags.asScala.map(t => t.key -> t.value).toMap
+      )
+    },
+    tags = vpc.tags.asScala.map(t => t.key -> t.value).toMap
+  )
+}
+
+case class Subnet(
+                   subnetArn: String,
+                   availabilityZone: String,
+                   cidrBlock: String,
+                   state: String,
+                   subnetId: String,
+                   ownerId: String,
+                   tags: Map[String, String] = Map.empty,
+                 )
+
+case class Vpc(
+                arn: String,
+                vpcId: String,
+                accountId: String,
+                state: String,
+                cidrBlock: String,
+                subnets: List[Subnet],
+                tags: Map[String, String] = Map.empty,
+              ) extends IndexedItemWithStage with IndexedItemWithStack {
+  def callFromArn: String => Call = arn => routes.Api.vpcs(arn)
+}
+

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -215,6 +215,14 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
       Api.singleItem(prismDataStore.rdsAgent, arn)
     }
 
+    def vpcList = Action.async { implicit request =>
+      Api.itemList(prismDataStore.vpcAgent, "vpcs")
+    }
+
+    def vpcs(arn: String) = Action.async { implicit request =>
+      Api.singleItem(prismDataStore.vpcAgent, arn)
+    }
+
     private def stackExtractor(i: IndexedItemWithStack) = i.stack.map(Json.toJson(_))
     private def stageExtractor(i: IndexedItemWithStage) = i.stage.map(Json.toJson(_))
     def roleList = summary[Instance](prismDataStore.instanceAgent, i => i.role.map(Json.toJson(_)), "roles")

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -30,6 +30,7 @@ class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
   val bucketAgent = new CollectorAgent[Bucket](new BucketCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val reservationAgent = new CollectorAgent[Reservation](new ReservationCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val rdsAgent = new CollectorAgent[Rds](new RdsCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
+  val vpcAgent = new CollectorAgent[Vpc](new VpcCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val allAgents = Seq(instanceAgent, lambdaAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
     serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent)
 }

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -32,5 +32,5 @@ class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
   val rdsAgent = new CollectorAgent[Rds](new RdsCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val vpcAgent = new CollectorAgent[Vpc](new VpcCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val allAgents = Seq(instanceAgent, lambdaAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
-    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent)
+    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent, vpcAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -68,6 +68,9 @@ object model {
   implicit val route53RecordWriter: Writes[Route53Record] = Json.writes[Route53Record]
   implicit val route53ZoneWriter: Writes[Route53Zone] = Json.writes[Route53Zone]
 
+  implicit val subnetWriter: Writes[Subnet] = Json.writes[Subnet]
+  implicit val vpcWriter: Writes[Vpc] = Json.writes[Vpc]
+
   implicit val loadBalancerWriter: Writes[LoadBalancer] = Json.writes[LoadBalancer]
 
   implicit val awsAccountWrites = Json.writes[AWSAccount]

--- a/conf/routes
+++ b/conf/routes
@@ -60,6 +60,9 @@ GET        /data/:arn                         controllers.Api.data(arn)
 GET        /rds-instances                     controllers.Api.rdsList
 GET        /rds-instances/:arn                controllers.Api.rds(arn)
 
+GET        /vpcs                              controllers.Api.vpcList
+GET        /vpcs/:arn                        controllers.Api.vpcs(arn)
+
 # Map static resources from the /public folder to the /assets URL path
 
 GET        /assets/*file                      controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -61,7 +61,7 @@ GET        /rds-instances                     controllers.Api.rdsList
 GET        /rds-instances/:arn                controllers.Api.rds(arn)
 
 GET        /vpcs                              controllers.Api.vpcList
-GET        /vpcs/:arn                        controllers.Api.vpcs(arn)
+GET        /vpcs/:arn                         controllers.Api.vpcs(arn)
 
 # Map static resources from the /public folder to the /assets URL path
 


### PR DESCRIPTION
## What does this change?
Here we add a VPC endpoint to Prism.

## Why is this important?

> We have a lot of VPC's at the guardian. These are typically created in two ways:
> - default VPC: comes with the AWS account - generally not recommended!
> - custom VPC: someone has thought about these and had to decide how the subnets in the VPC are split up. Still possibly a suboptimal setup.
> 
> VPCs have a block of IP addresses allocated to them. If set up correctly this will be a block registered with the networking team at the guardian so that one VPC doesn't share IP addresses with another.
> 
> It would be helpful to find out what the current state of play is with all VPCs - which ones are default, and what the IP ranges of each one is. At the same time it makes sense to check the layout of the VPC -e.g. is it the 'preferred' 3 private subnets, 3 public subnets or something different - e.g. dotcom has 3 public 1 private.

https://trello.com/c/ffqKl6oA

Adding VPCs to Prism will give us visibility over the IP ranges of our VPCs and we should be able to correct any that share IP addresses with one another.


## How to test
This is currently on CODE at https://prism.code.dev-gutools.co.uk/vpcs 🎉