### PR TITLE
Ophan Dev team owns stack tagged 'ophan'

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -67,7 +67,7 @@ object Owners extends Owners {
     "infosec.ops" -> SSA(stack = "infosec"),
     "infosec.ops" -> SSA(stack = "nessus"),
     "infosec.ops" -> SSA(stack = "secure-contact"),
-    "data.technology" -> SSA(stack = "ophan"),
+    "ophan.dev" -> SSA(stack = "ophan"),
     "data.technology" -> SSA(stack = "ophan-data-lake"),
     "reader.revenue.dev" -> SSA(stack = "membership"),
     "reader.revenue.dev" -> SSA(stack = "subscriptions"),


### PR DESCRIPTION
## What does this change?

@pvighi was kind enough [to point out](https://groups.google.com/a/guardian.co.uk/g/ophan.dev/c/JnhcX9AcFCY/m/8CMNUqHuAQAJ) that ophan.dev@theguardian.com wasn't getting _'Instances using out of date AMIs'_ messages (presumably sent by [Amiable](https://amiable.gutools.co.uk/instanceAMIs?stack=ophan)?) about our AMIs, because the ownership field here was still against data.technology@theguardian.com - fixing that!
