### PR TITLE
Upgrade to version 0.38.0 of @guardian/cdk

### DIFF
--- a/cdk/lib/__snapshots__/prism-access.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-access.test.ts.snap
@@ -90,7 +90,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "0.37.0",
+            "Value": "0.38.0",
           },
           Object {
             "Key": "Stack",

--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -2,6 +2,18 @@
 
 exports[`The Prism stack matches the snapshot 1`] = `
 Object {
+  "Mappings": Object {
+    "stagemapping": Object {
+      "CODE": Object {
+        "maxInstances": 4,
+        "minInstances": 2,
+      },
+      "PROD": Object {
+        "maxInstances": 4,
+        "minInstances": 2,
+      },
+    },
+  },
   "Parameters": Object {
     "AMI": Object {
       "Description": "AMI ID",
@@ -66,7 +78,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "0.37.0",
+            "Value": "0.38.0",
           },
           Object {
             "Key": "Stack",
@@ -85,30 +97,8 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "AppServerSecurityGroupfromprismLoadBalancerSecurityGroupA5954B5A90003B574E9E": Object {
-      "Properties": Object {
-        "Description": "Port 9000 LB to fleet",
-        "FromPort": 9000,
-        "GroupId": Object {
-          "Fn::GetAtt": Array [
-            "AppServerSecurityGroup",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": Object {
-          "Fn::GetAtt": Array [
-            "LoadBalancerSecurityGroupA28D6DD7",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "AutoscalingGroup": Object {
       "Properties": Object {
-        "DesiredCapacity": "2",
         "HealthCheckGracePeriod": 500,
         "HealthCheckType": "ELB",
         "LaunchConfigurationName": Object {
@@ -119,8 +109,24 @@ Object {
             "Ref": "LoadBalancer",
           },
         ],
-        "MaxSize": "4",
-        "MinSize": "2",
+        "MaxSize": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "maxInstances",
+          ],
+        },
+        "MinSize": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "minInstances",
+          ],
+        },
         "Tags": Array [
           Object {
             "Key": "App",
@@ -130,7 +136,7 @@ Object {
           Object {
             "Key": "gu:cdk:version",
             "PropagateAtLaunch": true,
-            "Value": "0.37.0",
+            "Value": "0.38.0",
           },
           Object {
             "Key": "Name",
@@ -192,6 +198,12 @@ Object {
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
+              "GuHttpsEgressSecurityGroupF63CDA96",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
               "AppServerSecurityGroup",
               "GroupId",
             ],
@@ -202,13 +214,9 @@ Object {
             "Fn::Join": Array [
               "",
               Array [
-                "#!/bin/bash -ev
-
-      aws --region ",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                " s3 cp s3://",
+                "#!/bin/bash
+mkdir -p $(dirname '/prism/prism.deb')
+aws s3 cp 's3://",
                 Object {
                   "Ref": "DistributionBucketName",
                 },
@@ -216,8 +224,8 @@ Object {
                 Object {
                   "Ref": "Stage",
                 },
-                "/prism/prism.deb /tmp/
-      dpkg -i /tmp/prism.deb",
+                "/prism/prism.deb' '/prism/prism.deb'
+dpkg -i /prism/prism.deb",
               ],
             ],
           },
@@ -395,6 +403,65 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "GuHttpsEgressSecurityGroupF63CDA96": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all outbound traffic on port 443",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "0.38.0",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupfromprismLoadBalancerSecurityGroupA5954B5A900093548ACB": Object {
+      "Properties": Object {
+        "Description": "Port 9000 LB to fleet",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupF63CDA96",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroupA28D6DD7",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "GuLogShippingPolicy981BFE5A": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -469,7 +536,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "0.37.0",
+            "Value": "0.38.0",
           },
           Object {
             "Key": "Stack",
@@ -525,7 +592,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "0.37.0",
+            "Value": "0.38.0",
           },
           Object {
             "Key": "Stack",
@@ -560,7 +627,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "0.37.0",
+            "Value": "0.38.0",
           },
           Object {
             "Key": "Stack",
@@ -579,12 +646,12 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "LoadBalancerSecurityGrouptoprismAppServerSecurityGroupA7BC420F9000EAD950C6": Object {
+    "LoadBalancerSecurityGrouptoprismGuHttpsEgressSecurityGroupD1B6EFA19000A7BEFB95": Object {
       "Properties": Object {
         "Description": "Port 9000 LB to fleet",
         "DestinationSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "AppServerSecurityGroup",
+            "GuHttpsEgressSecurityGroupF63CDA96",
             "GroupId",
           ],
         },

--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -97,6 +97,27 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "AppServerSecurityGroupfromprismLoadBalancerSecurityGroupA5954B5A90003B574E9E": Object {
+      "Properties": Object {
+        "Description": "Port 9000 LB to fleet",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "AppServerSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroupA28D6DD7",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "AutoscalingGroup": Object {
       "Properties": Object {
         "HealthCheckGracePeriod": 500,
@@ -645,6 +666,27 @@ dpkg -i /prism/prism.deb",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerSecurityGrouptoprismAppServerSecurityGroupA7BC420F9000EAD950C6": Object {
+      "Properties": Object {
+        "Description": "Port 9000 LB to fleet",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "AppServerSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityGroupA28D6DD7",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "LoadBalancerSecurityGrouptoprismGuHttpsEgressSecurityGroupD1B6EFA19000A7BEFB95": Object {
       "Properties": Object {

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -1,5 +1,5 @@
 import { BlockDeviceVolume, EbsDeviceVolumeType, HealthCheck } from "@aws-cdk/aws-autoscaling";
-import { Peer } from "@aws-cdk/aws-ec2";
+import { Peer, Port } from "@aws-cdk/aws-ec2";
 import type { App } from "@aws-cdk/core";
 import { Duration } from "@aws-cdk/core";
 import { Stage } from "@guardian/cdk/lib/constants";
@@ -86,7 +86,7 @@ export class PrismStack extends GuStack {
       ],
     });
 
-    new GuHttpsClassicLoadBalancer(this, "LoadBalancer", {
+    const loadBalancer = new GuHttpsClassicLoadBalancer(this, "LoadBalancer", {
       vpc,
       crossZone: true,
       subnetSelection: { subnets },
@@ -101,5 +101,7 @@ export class PrismStack extends GuStack {
         allowConnectionsFrom: [Peer.ipv4("10.0.0.0/8")],
       },
     });
+
+    appServerSecurityGroup.connections.allowFrom(loadBalancer, Port.tcp(9000), "Port 9000 LB to fleet");
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.90.0",
-    "@guardian/cdk": "0.37.0",
+    "@guardian/cdk": "0.38.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -1053,10 +1053,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-0.37.0.tgz#7a1fd2c5dd44a5bc36f288087369e1b86ef0b5f6"
-  integrity sha512-s7dMyQGRxaasJXTI7dfnPIguhDqQ1l9SghRPfCVrbQlCg0/o988HP6rYMpNtAQJe5P5pjGxapJPDApN/4kUdAA==
+"@guardian/cdk@0.38.0":
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-0.38.0.tgz#4686e75f39330ed1d5d311dfa504aba5309256a5"
+  integrity sha512-oTowfGSW0lFrsio2yPRYjC9h/H8X26KNvIXhpF7nl4dAHIo/y75eidbIlKLoQDZvu+XAW4onqyXKSvGja34Big==
   dependencies:
     "@aws-cdk/assert" "1.90.0"
     "@aws-cdk/aws-apigateway" "1.90.0"


### PR DESCRIPTION
## What does this change?

Updates Prism to use `@guardian/cdk` [version 0.38.0](https://github.com/guardian/cdk/releases/tag/v0.38.0). I've commented on the diff below to explain the most significant changes in more detail.

## How to test

I've tested this by deploying the change to `CODE` and confirming that Prism remained accessible throughout the deployment.

## How can we measure success?

* Prism should continue to operate normally during and after the upgrade.

## Have we considered potential risks?

* We're updating security groups and that always feels a bit risky! I think that the testing done mitigates this risk sufficiently though.