### PR TITLE
Fix Riff-Raff warning

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,6 @@ deployments:
     app: prism
     parameters:
       templatePath: Prism.template.json
-      amiParameter: AMI
       amiEncrypted: true
       amiTags:
         Recipe: bionic-java8-deploy-infrastructure


### PR DESCRIPTION
## What does this change?

Riff-Raff is warning us that `Parameter amiParameter is unnecessarily explicitly set to the default value of AMI`, so I've removed this superfluous line.

## How to test

I've tested this by [deploying to `CODE`](https://riffraff.gutools.co.uk/deployment/view/87bffb04-9209-4377-b54e-35a87faf4435).

## How can we measure success?

* Riff-Raff should deploy this project with 0 warnings.