### PR TITLE
Migrate to ARM64

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,7 @@ deployments:
       amiParameter: AMI
       amiEncrypted: true
       amiTags:
-        Recipe: bionic-java8-deploy-infrastructure
+        Recipe: arm64-bionic-java8-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
   prism:


### PR DESCRIPTION
## What does this change?
Switches prism to using an ARM64 amigo recipe. 

## How to test
I've tested on CODE and things seem ok. To deploy this to PROD:

 - Update instance type manually of prism-PROD via cloudformation
 - Merge this change
 - Wait for continuous deployment to kick in 
 - Test prism.gutools.co.uk
