### PR TITLE
Migrate to Java 11 runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,11 +78,9 @@ lazy val root = (project in file("."))
 
 javaOptions in Universal ++= Seq(
   "-Dpidfile.path=/dev/null",
-  "-J-XX:MaxRAMFraction=2",
-  "-J-XX:InitialRAMFraction=2",
+  "-J-XX:MaxRAMPercentage=60",
+  "-J-XX:InitialRAMPercentage=60",
   "-J-XX:MaxMetaspaceSize=300m",
-  "-J-XX:+PrintGCDetails",
-  "-J-XX:+PrintGCDateStamps",
-  s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
+  s"-J-Xlog:gc*:file=/var/log/${packageName.value}/gc.log:time:filecount=5,filesize=1024K"
 )
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,7 @@ deployments:
       amiParameter: AMI
       amiEncrypted: true
       amiTags:
-        Recipe: arm64-bionic-java8-deploy-infrastructure
+        Recipe: arm64-bionic-java11-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
   prism:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,6 @@ deployments:
     app: prism
     parameters:
       templatePath: Prism.template.json
-      amiParameter: AMI
       amiEncrypted: true
       amiTags:
         Recipe: arm64-bionic-java11-deploy-infrastructure


### PR DESCRIPTION
## What does this change?
Under ARM64 we are seeing performance issues linked to the Java 8 runtime not having been optimised for the new architecture. This PR migrates prism to Java 11 which does have optimisations for ARM64.

Note that we commonly use a number of command line options that have been removed or deprecated in Java 11.

## How to test
Does prism still work after deploy? Are the GC logs still there?

## How can we measure success?
Might be worth looking at average CPU usage before and after deployment.

## Have we considered potential risks?
 * This might be unreliable as we've not really used Java 11 anywhere. 
 * We've translated JVM parameters from 8 to 11, the translation might be wrong.
 * There is a new AMIgo role which might have errors.

That said Java 11 is widely used and we are still compiling under JDK8 so this should be low risk.