### PR TITLE
chore(deps): bump the versions of the AWS SDKs for Java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ resolvers ++= Seq(
 
 val awsVersion = "2.16.25"
 val awsVersionOne = "1.11.981"
+val playJsonVersion = "2.9.2"
+val jacksonVersion = "2.10.1"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
@@ -55,13 +57,14 @@ lazy val root = (project in file("."))
       "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommanderbu
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersionOne,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersionOne,
-      "com.typesafe.play" %% "play-json" % "2.9.1",
-      "com.typesafe.play" %% "play-json-joda" % "2.9.1",
+      "com.typesafe.play" %% "play-json" % playJsonVersion,
+      "com.typesafe.play" %% "play-json-joda" % playJsonVersion,
       "ai.x" %% "play-json-extensions" % "0.42.0",
       ws,
       "org.scala-stm" %% "scala-stm" % "0.9.1",
       filters,
       specs2 % "test",
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.4" exclude("com.fasterxml.jackson.core", "jackson-databind"),
       "com.gu" % "kinesis-logback-appender" % "2.0.1",
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "2.15.31"
-val awsVersionOne = "1.11.918"
+val awsVersion = "2.16.25"
+val awsVersionOne = "1.11.981"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, BuildInfoPlugin)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The primary aim of this is to get the latest list of Lambda runtimes as we're currently failing to crawl lambdas using the Node14 runtime.

This is the stacktrace seen on PROD:

```
java.lang.NullPointerException: null
	at collectors.Lambda$.fromApiData(lambda.scala:48)
	at collectors.AWSLambdaCollector.$anonfun$crawl$2(lambda.scala:36)
	at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:99)
	at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:86)
	at scala.collection.mutable.ArrayBuffer.map(ArrayBuffer.scala:40)
	at collectors.AWSLambdaCollector.crawl(lambda.scala:30)
	at agent.Datum$.$anonfun$apply$1(model.scala:77)
	at scala.util.Try$.apply(Try.scala:210)
	at agent.Datum$.apply(model.scala:76)
	at agent.CollectorAgent.update(collector.scala:41)
	at agent.CollectorAgent$$anonfun$1.$anonfun$applyOrElse$1(collector.scala:83)
	at utils.ScheduledAgent.$anonfun$queueUpdate$1(ScheduledAgent.scala:107)
	at scala.concurrent.stm.ccstm.NonTxn$.transformAndGetImpl(NonTxn.scala:402)
	at scala.concurrent.stm.ccstm.NonTxn$.transformAndGet(NonTxn.scala:399)
	at scala.concurrent.stm.ccstm.ViewOps.transform(ViewOps.scala:54)
	at scala.concurrent.stm.ccstm.ViewOps.transform$(ViewOps.scala:53)
	at scala.concurrent.stm.ccstm.CCSTMRefs$BaseRef.transform(CCSTMRefs.scala:46)
	at akka.agent.Agent$SecretAgent$$anon$3$$anon$4.run(Agent.scala:51)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:48)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Observe the healthcheck passing

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We can deploy!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a