### PR TITLE
chore(deps): Update AWS SDK V2 (2.15.75)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "2.15.31"
+val awsVersion = "2.15.75"
 val awsVersionOne = "1.11.918"
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Update to the earliest version that adds the node14 lambda runtime (see https://github.com/aws/aws-sdk-java-v2/blob/7a73d3ed2ad8174a3d74a093b75761ca0c00222f/CHANGELOG.md#L794-L821).

It's worth noting that updating to the latest AWS SDK versions [didn't work](https://github.com/guardian/prism/pull/160/commits/2002024a8fb40ba0d7fbae2dbde94ca3cd098119) due to a jackson-databind issue. It looks like the AWS SDKs [requires Jackson 2.12.1 since 2.16.0](https://github.com/aws/aws-sdk-java-v2/pull/2286) (see stacktrace below). I'm hoping I can be lazy and not invest too much time trying to fix this...

<details>
<summary>stacktrace</summary>

```
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]: Oops, cannot start the server.
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]: com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.3 requires Jackson Databind version >= 2.10.0 and < 2.11.0
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at com.fasterxml.jackson.module.scala.JacksonModule.setupModule(JacksonModule.scala:61)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at com.fasterxml.jackson.module.scala.JacksonModule.setupModule$(JacksonModule.scala:46)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at com.fasterxml.jackson.module.scala.DefaultScalaModule.setupModule(DefaultScalaModule.scala:17)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:835)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at com.fasterxml.jackson.databind.ObjectMapper.registerModules(ObjectMapper.java:1037)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at com.fasterxml.jackson.databind.ObjectMapper.findAndRegisterModules(ObjectMapper.java:1115)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at net.logstash.logback.composite.CompositeJsonFormatter.createJsonFactory(CompositeJsonFormatter.java:131)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at net.logstash.logback.composite.CompositeJsonFormatter.start(CompositeJsonFormatter.java:104)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at net.logstash.logback.LogstashFormatter.start(LogstashFormatter.java:154)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at net.logstash.logback.layout.CompositeJsonLayout.start(CompositeJsonLayout.java:98)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at conf.LogConfiguration$.shipping(LogConfiguration.scala:33)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at AppLoader.load(AppLoader.scala:40)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at play.core.server.ProdServerStart$.start(ProdServerStart.scala:54)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at play.core.server.ProdServerStart$.main(ProdServerStart.scala:30)
Mar 24 18:07:47 ip-10-248-49-44 prism[3183]:         at play.core.server.ProdServerStart.main(ProdServerStart.scala)
```

</details>

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Witness CODE's healthcheck passing

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

CD is re-enabled.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a