### PR TITLE
Add new route for monitoring cdk usage

### DIFF
--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -19,6 +19,20 @@ trait IndexedItem {
   def fieldIndex: Map[String, String] = Map("arn" -> arn)
 }
 
+trait IndexedItemWithCoreTags extends
+  IndexedItemWithApp with
+  IndexedItemWithGuCdkVersion with
+  IndexedItemWithStage with
+  IndexedItemWithStack
+
+trait IndexedItemWithApp extends IndexedItem {
+  val app: List[String] = Nil
+}
+
+trait IndexedItemWithGuCdkVersion extends IndexedItem {
+  val guCdkVersion: Option[String] = None
+}
+
 trait IndexedItemWithStage extends IndexedItem {
   val stage: Option[String] = None
 }

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -101,10 +101,11 @@ object Instance {
       stage = tags.get("Stage"),
       stack = stack,
       app = app,
+      guCdkVersion = tags.get("gu:cdk:version"),
       mainclasses = tags.get("Mainclass").map(_.split(",").toList).orElse(stack.map(stack => app.map(a => s"$stack::$a"))).getOrElse(Nil),
       role = tags.get("Role"),
       management = ManagementEndpoint.fromTag(addresses.primary.dnsName, tags.get("Management")),
-      Some(specs)
+      specification = Some(specs)
     )
   }
 }
@@ -174,12 +175,13 @@ case class Instance(
                  tags: Map[String, String] = Map.empty,
                  override val stage: Option[String],
                  override val stack: Option[String],
-                 app: List[String],
+                 override val app: List[String],
+                 override val guCdkVersion: Option[String],
                  mainclasses: List[String],
                  role: Option[String],
                  management:Option[Seq[ManagementEndpoint]],
                  specification:Option[InstanceSpecification]
-                ) extends IndexedItemWithStage with IndexedItemWithStack {
+                ) extends IndexedItemWithCoreTags {
 
   def callFromArn: String => Call = arn => routes.Api.instance(arn)
   override lazy val fieldIndex: Map[String, String] = super.fieldIndex ++ Map("dnsName" -> dnsName) ++ stage.map("stage" ->)

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -63,6 +63,8 @@ object Lambda extends Logging{
     region,
     runtime = getRuntime(lambda),
     tags,
+    app = tags.get("App").map(_.split(",").toList).getOrElse(Nil),
+    guCdkVersion = tags.get("gu:cdk:version"),
     stage = tags.get("Stage"),
     stack = tags.get("Stack")
   )
@@ -74,8 +76,10 @@ case class Lambda(
   region: String,
   runtime: String,
   tags: Map[String, String],
+  override val app: List[String],
+  override val guCdkVersion: Option[String],
   override val stage: Option[String],
   override val stack: Option[String]
-) extends IndexedItemWithStage with IndexedItemWithStack {
+) extends IndexedItemWithCoreTags {
   override def callFromArn: (String) => Call = arn => routes.Api.instance(arn)
 }

--- a/conf/routes
+++ b/conf/routes
@@ -10,6 +10,7 @@ GET        /sources/accounts                  controllers.Api.sourceAccounts
 GET        /management/healthcheck            controllers.Api.healthCheck
 
 GET        /apps                              controllers.Api.appList
+GET        /apps-with-cdk-version             controllers.Api.appsWithCdkVersion
 GET        /stacks                            controllers.Api.stackList
 GET        /stages                            controllers.Api.stageList
 


### PR DESCRIPTION
## What does this change?

1. Adds a new `/apps-with-cdk-version` route, so that we can track adoption/upgrade status of https://github.com/guardian/cdk across our estate
2. Updates the `/apps` response so that lambda-based apps are also included (this was previously reporting EC2-based apps only, which I think is a bug/oversight)
3. Adds `app` information to `/lambdas` response (where relevant)
4. Adds `guCdkVersion` information to `/instances` and `/lambdas` responses (where relevant)

In order to support 1, I considered an alternative implementation based on querying all stacks via the CloudFormation API. I decided not to pursue this as it would have required new IAM permissions and scraping of additional AWS data. It would also likely have been harder/slower to implement than the implementation proposed in this PR!

## How to test

This change is on `CODE` at the time of writing and seems to be working as expected.

## How can we measure success?

It's possible to find out which projects have started using `guardian/cdk`. In the future we'll also be able to use this to identify projects running with older versions of the library.

## Have we considered potential risks?

I think this should be safe as we are only adding new responses / adding more fields to existing responses. We are not fetching any new data from AWS to support this functionality so it should not significantly affect performance. 

There is a small risk that a client is relying on the EC2-only nature of the current `/apps` response, but I think this is unlikely.