### PR TITLE
refactor: Use `@guardian/cdk` mock to ease version upgrades

### DIFF
--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -1,5 +1,6 @@
 *.js
 !jest.config.js
+!jest.setup.js
 !.eslintrc.js
 *.d.ts
 node_modules

--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,0 +1,2 @@
+jest.mock("@guardian/cdk/lib/constants/library-info");
+

--- a/cdk/lib/__snapshots__/prism-access.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-access.test.ts.snap
@@ -90,7 +90,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",

--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -78,7 +78,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -157,7 +157,7 @@ Object {
           Object {
             "Key": "gu:cdk:version",
             "PropagateAtLaunch": true,
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Name",
@@ -443,7 +443,7 @@ dpkg -i /prism/prism.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -557,7 +557,7 @@ dpkg -i /prism/prism.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -613,7 +613,7 @@ dpkg -i /prism/prism.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",
@@ -648,7 +648,7 @@ dpkg -i /prism/prism.deb",
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "8.2.0",
+            "Value": "TEST",
           },
           Object {
             "Key": "Stack",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.97.0",
-    "@guardian/cdk": "8.2.0",
+    "@guardian/cdk": "8.4.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -1085,10 +1085,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-8.2.0.tgz#639c1d3175534e72fb82a126737eeb21826f79bb"
-  integrity sha512-4hJDgbojDW4pIbuwh745sPuN30fLMtlruy0i3FbdtMvt/1DsVD9fhLjrWufpXq+qw/Cq6e6iJM7rDM3D7/QDoQ==
+"@guardian/cdk@8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-8.4.0.tgz#988d654223d8c79cb855c532f9cb8ca22394cc80"
+  integrity sha512-O+p1Tsseuoq/OQCgjcTiMPh5pZlEqI2n4p0kiElSJ3sX1DKGNPqKUFUv9/kexh0+iGmtbCqdEUGxQNOLtN3yKg==
   dependencies:
     "@aws-cdk/assert" "1.97.0"
     "@aws-cdk/aws-apigateway" "1.97.0"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

It is currently impossible to use Dependabot to update `@guardian/cdk`.

Dependabot will raise a PR to update the version of `@guardian/cdk` in `package.json` and nothing else.

This PR will always fail CI as the value of the `gu:cdk:version` tag in our snapshots is tied to the version of `@guardian/cdk` being used.

That is, if Dependabot raises a PR to move from v1 to v2, as the snaphots are not updated at the same time, the tests fail.

In this change, we use the newly published mock in `@guardian/cdk` which results in the value of `gu:cdk:version` in the snapshots being static and thus Dependabot PRs become usable and we update `@guardian/cdk` more frequently.

I've followed the steps listed [here](https://github.com/guardian/cdk/blob/ef9f9aca26ca7aae071a9606850b56962d39dc06/docs/001-general-usage.md#-mocking-gucdkversion).

This does not affect the production template generated by `cdk synth`.

See:
 - guardian/cdk#448

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

It's a little tricky as there is a timer involved and can only be done once this is merged, but:

- Update `@guardian/cdk` to a new patch or minor version
- Wait for Dependabot to raise a PR to update `@guardian/cdk`
- Witness CI of that PR pass
- Merge and move on

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Prism is kept up to date with `@guardian/cdk` at a steady pace.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

I don't think there are any. If there are breaking changes in `@guardian/cdk` the tests will fail and so we would need to manually intervene to fix them. That is, there is no negative impact to the running infrastructure.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a