### PR TITLE
Bump riffraff plugin to use one from Maven Central

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 // The Typesafe repository 
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 


### PR DESCRIPTION
## What does this change?
This is a check that the migration of the riffraff plugin to maven central in https://github.com/guardian/sbt-riffraff-artifact/pull/56 has worked successfully.

## How to test
Confirm that the build passes and can be deployed successfully, checking the build metadata in particular.

## Have we considered potential risks?
Yes, this mitigates some risk by confirming that the moved pluign still works as expected.
