### PR TITLE
fix: Make lambda runtime easier to use

### DIFF
--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -40,10 +40,7 @@ case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType, craw
 }
 
 object Lambda extends Logging{
-  // converts `null` to `"unknown"`
-  private def safeNull(string: String) = Option(string).getOrElse("unknown")
-
-  private def getRuntime(lambda: FunctionConfiguration): String = {
+  private def getRuntime(lambda: FunctionConfiguration): Option[String] = {
     if(lambda.runtime == Runtime.UNKNOWN_TO_SDK_VERSION) {
       log.warn(s"Lambda runtime ${lambda.runtimeAsString} isn't recognised in the AWS SDK. Is there a later version of the AWS SDK available?")
     }
@@ -57,15 +54,15 @@ object Lambda extends Logging{
 
     See: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/lambda/model/FunctionConfiguration.html#runtimeAsString--
      */
-    safeNull(lambda.runtimeAsString)
+    Option(lambda.runtimeAsString) // remove `null`s
   }
 
-  private def getPackageType(lambda: FunctionConfiguration): String = {
+  private def getPackageType(lambda: FunctionConfiguration): Option[String] = {
     if(lambda.packageType == PackageType.UNKNOWN_TO_SDK_VERSION){
       log.warn(s"Lambda package type ${lambda.packageTypeAsString} isn't recognised in the AWS SDK. Is there a later version of the AWS SDK available?")
     }
 
-    safeNull(lambda.packageTypeAsString)
+    Option(lambda.packageTypeAsString) // remove `null`s
   }
 
   def fromApiData(lambda: FunctionConfiguration, region: String, tags: Map[String, String]): Lambda = Lambda(
@@ -86,8 +83,8 @@ case class Lambda(
   arn: String,
   name: String,
   region: String,
-  runtime: String,
-  packageType: String,
+  runtime: Option[String],
+  packageType: Option[String],
   tags: Map[String, String],
   override val app: List[String],
   override val guCdkVersion: Option[String],

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -40,6 +40,9 @@ case class AWSLambdaCollector(origin: AmazonOrigin, resource: ResourceType, craw
 }
 
 object Lambda extends Logging{
+  // converts `null` to `"unknown"`
+  private def safeNull(string: String) = Option(string).getOrElse("unknown")
+
   private def getRuntime(lambda: FunctionConfiguration): String = {
     if(lambda.runtime == Runtime.UNKNOWN_TO_SDK_VERSION) {
       log.warn(s"Lambda runtime ${lambda.runtimeAsString} isn't recognised in the AWS SDK. Is there a later version of the AWS SDK available?")
@@ -54,7 +57,7 @@ object Lambda extends Logging{
 
     See: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/lambda/model/FunctionConfiguration.html#runtimeAsString--
      */
-    lambda.runtimeAsString
+    safeNull(lambda.runtimeAsString)
   }
 
   def fromApiData(lambda: FunctionConfiguration, region: String, tags: Map[String, String]): Lambda = Lambda(

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "2.15.31"
+val awsVersion = "2.16.58"
 val awsVersionOne = "1.11.918"
 
 lazy val root = (project in file("."))
@@ -64,6 +64,7 @@ lazy val root = (project in file("."))
       specs2 % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "6.4" exclude("com.fasterxml.jackson.core", "jackson-databind"),
       "com.gu" % "kinesis-logback-appender" % "2.0.1",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.2",
     ),
     scalacOptions ++= List(
       "-encoding", "utf8",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Makes two changes to improve the lambda collection:
  1. Improve handling of `null` lambda runtimes
  2. Expose lambda package type

### Improve handling of `null` lambda runtimes
The runtime for a lambda is optional and will be `null` when the lambda is running a container.

We're seeing this `null` cause issues when filtering via regex, for example `/lambdas?runtime~=nodejs.*`.

<details>
<summary>Stack trace caused by regex filtering of runtime with `null`s</summary>

```
"java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1770)",
"java.base/java.util.regex.Matcher.reset(Matcher.java:416)",
"java.base/java.util.regex.Matcher.<init>(Matcher.java:253)",
"java.base/java.util.regex.Pattern.matcher(Pattern.java:1133)",
"scala.util.matching.Regex.unapplySeq(Regex.scala:283)",
"utils.RegExMatchable.isMatch(filter.scala:14)",
"utils.RegExMatchable.isMatch(filter.scala:13)",
"utils.ResourceFilter.$anonfun$isMatch$5(filter.scala:24)",
"utils.ResourceFilter.$anonfun$isMatch$5$adapted(filter.scala:24)",
"scala.collection.immutable.List.exists(List.scala:395)",
"utils.ResourceFilter.$anonfun$isMatch$4(filter.scala:24)",
"utils.ResourceFilter.$anonfun$isMatch$4$adapted(filter.scala:23)",
"scala.collection.immutable.Map$Map1.forall(Map.scala:263)",
"utils.ResourceFilter.isMatch(filter.scala:23)",
"utils.ResourceFilter.isMatch(filter.scala:19)",
"controllers.Api$.itemJson(Api.scala:323)",
"controllers.Api$.$anonfun$itemList$3(Api.scala:338)",
"scala.collection.immutable.List.flatMap(List.scala:293)",
"scala.collection.immutable.List.flatMap(List.scala:79)",
"controllers.Api$.$anonfun$itemList$2(Api.scala:338)",
"scala.collection.immutable.List.map(List.scala:250)",
"scala.collection.immutable.List.map(List.scala:79)",
"controllers.Api$.$anonfun$itemList$1(Api.scala:336)",
"scala.util.Try$.apply(Try.scala:210)",
"controllers.ApiResult$filter$.apply(ApiResult.scala:118)",
"controllers.Api$.itemList(Api.scala:333)",
"controllers.Api.$anonfun$lambdaList$1(Api.scala:141)",
"play.api.mvc.ActionBuilderImpl.invokeBlock(Action.scala:441)",
"play.api.mvc.ActionBuilderImpl.invokeBlock(Action.scala:439)",
"play.api.mvc.ActionBuilder$$anon$9.apply(Action.scala:379)",
"play.api.mvc.Action.$anonfun$apply$4(Action.scala:82)",
"play.api.libs.streams.StrictAccumulator.$anonfun$mapFuture$4(Accumulator.scala:168)",
"scala.util.Try$.apply(Try.scala:210)",
"play.api.libs.streams.StrictAccumulator.$anonfun$mapFuture$3(Accumulator.scala:168)",
"scala.Function1.$anonfun$andThen$1(Function1.scala:85)",
"scala.Function1.$anonfun$andThen$1(Function1.scala:85)",
"scala.Function1.$anonfun$andThen$1(Function1.scala:85)",
"scala.Function1.$anonfun$andThen$1(Function1.scala:85)",
"play.api.libs.streams.StrictAccumulator.run(Accumulator.scala:199)",
"play.core.server.AkkaHttpServer.$anonfun$runAction$4(AkkaHttpServer.scala:416)",
"akka.http.scaladsl.util.FastFuture$.strictTransform$1(FastFuture.scala:41)",
"akka.http.scaladsl.util.FastFuture$.$anonfun$transformWith$3(FastFuture.scala:51)",
"scala.concurrent.impl.Promise$Transformation.run(Promise.scala:447)",
"akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:56)",
"akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:93)",
"scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)",
"scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)",
"akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:93)",
"akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:48)",
"akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)",
"java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)",
"java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)",
"java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)",
"java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)",
"java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)"
```

</details>

Convert `runtime` to an `Option`, meaning any `null` values will simply be omitted in the response.

To filter for them, we'd need to use `jq` or implement another operator, for example `!runtime`.

It should be safe to assume that a lambda without a runtime will have a package type of `Image`.

### Expose lambda package type
The package type is:

> The type of deployment package. Set to Image for container image and set Zip for .zip file archive.

If the package type is `"Image"` then the lambda runtime is `null`. Exposing package type provides some context to a `null` runtime.

This requires an update of the AWS SDK (2.16.58 is the current latest). To support this, we have to add `jackson-module-scala` to solve the issue of:

```
com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.5 requires Jackson Databind version >= 2.10.0 and < 2.11.0
```

I don't fully understand how this solves things... Pasting random code from the internet has served me well so far 😬.

See:
  - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-packagetype
  - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime
  - FasterXML/jackson-module-scala#513 (comment)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

  - Deploy `main` to CODE
  - Go to `/lambdas?runtime~=nodejs.*`
  - Witness an error as described above
  - Deploy this branch to CODE
  - Go to `/lambdas?runtime~=nodejs.*`
  - Witness a successful response

For bonus points, with this branch on CODE:
  - Go to `/lambdas?runtime=unknown`
  - Witness a number of lambdas being returned and their `packageType` field set to `Image` (it'll be `Zip` otherwise)

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We're able to use regex filters on the lambda runtime 🎉 . I believe this is currently being used to find lambdas using [a deprecated runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).