### PR TITLE
Crawl cloudformation stacks and resources

### DIFF
--- a/app/collectors/cloudformationStacks.scala
+++ b/app/collectors/cloudformationStacks.scala
@@ -69,8 +69,11 @@ object CloudformationStack {
         CloudformationStackOutput(
           description = Option(output.description),
           exportName = Option(output.exportName),
-          key = Option(output.outputKey),
-          value = Option(output.outputValue)
+          key = None,
+          value = None,
+          // commented out whilst we figure out whether it's safe to display all values
+          // key = Option(output.outputKey),
+          // value = Option(output.outputValue)
         )
       },
       parameters = Option(stack.parameters).toList.flatMap(_.asScala).map { param =>

--- a/app/collectors/cloudformationStacks.scala
+++ b/app/collectors/cloudformationStacks.scala
@@ -1,0 +1,158 @@
+package collectors
+
+import agent._
+import conf.AWS
+import controllers.routes
+import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.mvc.Call
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient
+import software.amazon.awssdk.services.cloudformation.model.{DescribeStackResourcesRequest, DescribeStacksRequest, GetStackPolicyRequest, GetStackPolicyResponse, ListStacksRequest, Stack, StackResource, StackStatus, StackSummary}
+import utils.Logging
+
+import java.time.Instant
+import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
+import scala.util.Try
+
+class CloudformationStackCollectorSet(accounts: Accounts) extends CollectorSet[CloudformationStack](ResourceType("cloudformationStacks"), accounts, Some(Regional)) {
+
+  val lookupCollector: PartialFunction[Origin, Collector[CloudformationStack]] = {
+    case amazon: AmazonOrigin => CloudformationStackCollector(amazon, resource, amazon.crawlRate(resource.name))
+  }
+}
+
+case class CloudformationStackCollector(origin: AmazonOrigin, resource: ResourceType, crawlRate: CrawlRate) extends Collector[CloudformationStack] with Logging {
+
+  val client: CloudFormationClient = CloudFormationClient
+    .builder
+    .credentialsProvider(origin.credentials.provider)
+    .region(origin.awsRegionV2)
+    .overrideConfiguration(AWS.clientConfig)
+    .build
+
+  def crawl: Iterable[CloudformationStack] = {
+    client.describeStacksPaginator(DescribeStacksRequest.builder.build).asScala
+      .flatMap(_.stacks.asScala)
+      .filterNot(_.stackStatusAsString == StackStatus.DELETE_COMPLETE.toString)
+      .map{ stack =>
+        val resources = client.describeStackResources(DescribeStackResourcesRequest.builder.stackName(stack.stackName).build)
+        val policy = client.getStackPolicy(GetStackPolicyRequest.builder.stackName(stack.stackName).build)
+        CloudformationStack.fromApiData(stack, resources.stackResources.asScala, Option(policy.stackPolicyBody))
+      }
+  }
+}
+
+object CloudformationStack {
+  def fromApiData(stack: Stack, resources: Iterable[StackResource], policy: Option[String]): CloudformationStack = {
+    CloudformationStack(
+      arn = stack.stackId,
+      name = stack.stackName,
+      status = stack.stackStatusAsString,
+      statusReason = Option(stack.stackStatusReason),
+      description = Option(stack.description),
+      creationTime = stack.creationTime,
+      driftInformation = Option(stack.driftInformation).map { driftInformation =>
+        CloudformationStackDriftInformation(
+          lastCheckTimestamp = Option(driftInformation.lastCheckTimestamp),
+          status = driftInformation.stackDriftStatusAsString
+        )
+      },
+      lastUpdatedTime = Option(stack.lastUpdatedTime),
+      parentId = Option(stack.parentId),
+      rootId = Option(stack.rootId),
+      tags = stack.tags.asScala.map { tag =>
+        tag.key -> tag.value
+      }.toMap,
+      disableRollback = Option(stack.disableRollback),
+      terminationProtection = Option(stack.enableTerminationProtection),
+      outputs = Option(stack.outputs).toList.flatMap(_.asScala).map { output =>
+        CloudformationStackOutput(
+          description = Option(output.description),
+          exportName = Option(output.exportName),
+          key = Option(output.outputKey),
+          value = Option(output.outputValue)
+        )
+      },
+      parameters = Option(stack.parameters).toList.flatMap(_.asScala).map { param =>
+        CloudformationStackParameter(
+          key = Option(param.parameterKey)
+// commented out whilst we figure out whether it's safe to display all values in case more secrets are added without NoEcho
+//          value = Option(param.parameterValue),
+//          resolvedValue = Option(param.resolvedValue)
+        )
+      },
+      resources = resources.map { resource =>
+        resource.description()
+        CloudformationStackResource(
+          logicalResourceId = resource.logicalResourceId,
+          physicalResourceId = Option(resource.physicalResourceId),
+          description = Option(resource.description),
+          driftInformation = Option(resource.driftInformation).map { driftInformation =>
+            CloudformationStackDriftInformation(
+              lastCheckTimestamp = Option(driftInformation.lastCheckTimestamp),
+              status = driftInformation.stackResourceDriftStatusAsString
+            )
+          },
+          status = resource.resourceStatusAsString,
+          statusReason = Option(resource.resourceStatusReason),
+          resourceType = resource.resourceType,
+          timestamp = resource.timestamp
+        )
+      }.toList,
+      policy = policy.map { p =>
+        Try(Json.parse(p)).toOption.getOrElse(JsString(s"Unable to parse policy $policy"))
+      }
+    )
+  }
+}
+
+case class CloudformationStackDriftInformation(
+  lastCheckTimestamp: Option[Instant],
+  status: String
+)
+
+case class CloudformationStackOutput(
+  description: Option[String],
+  exportName: Option[String],
+  key: Option[String],
+  value: Option[String]
+)
+
+case class CloudformationStackParameter(
+  key: Option[String],
+//  value: Option[String],
+//  resolvedValue: Option[String]
+)
+
+case class CloudformationStackResource(
+  logicalResourceId: String,
+  physicalResourceId: Option[String],
+  description: Option[String],
+  driftInformation: Option[CloudformationStackDriftInformation],
+  status: String,
+  statusReason: Option[String],
+  resourceType: String,
+  timestamp: Instant
+)
+
+case class CloudformationStack(
+  arn: String,
+  name: String,
+  status: String,
+  statusReason: Option[String],
+  description: Option[String],
+  creationTime: Instant,
+  driftInformation: Option[CloudformationStackDriftInformation],
+  lastUpdatedTime: Option[Instant],
+  parentId: Option[String],
+  rootId: Option[String],
+  tags: Map[String, String],
+  disableRollback: Option[Boolean],
+  terminationProtection: Option[Boolean],
+  outputs: List[CloudformationStackOutput],
+  parameters: List[CloudformationStackParameter],
+  resources: List[CloudformationStackResource],
+  policy: Option[JsValue]
+) extends IndexedItem {
+  def callFromArn: (String) => Call = arn => routes.Api.cloudformationStack(arn)
+}

--- a/app/collectors/cloudformationStacks.scala
+++ b/app/collectors/cloudformationStacks.scala
@@ -75,7 +75,9 @@ object CloudformationStack {
       },
       parameters = Option(stack.parameters).toList.flatMap(_.asScala).map { param =>
         CloudformationStackParameter(
-          key = Option(param.parameterKey)
+          key = Option(param.parameterKey),
+          value = None,
+          resolvedValue = None
 // commented out whilst we figure out whether it's safe to display all values in case more secrets are added without NoEcho
 //          value = Option(param.parameterValue),
 //          resolvedValue = Option(param.resolvedValue)
@@ -120,8 +122,9 @@ case class CloudformationStackOutput(
 
 case class CloudformationStackParameter(
   key: Option[String],
-//  value: Option[String],
-//  resolvedValue: Option[String]
+// commented out whilst we figure out whether it's safe to display all values in case more secrets are added without NoEcho
+  value: Option[String],
+  resolvedValue: Option[String]
 )
 
 case class CloudformationStackResource(

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -223,6 +223,14 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
       Api.singleItem(prismDataStore.vpcAgent, arn)
     }
 
+    def cloudformationStackList = Action.async { implicit request =>
+      Api.itemList(prismDataStore.cloudformationStackAgent, "cloudformation-stacks")
+    }
+
+    def cloudformationStack(arn: String) = Action.async { implicit request =>
+      Api.singleItem(prismDataStore.cloudformationStackAgent, arn)
+    }
+
     private def stackExtractor(i: IndexedItemWithStack) = i.stack.map(Json.toJson(_))
     private def stageExtractor(i: IndexedItemWithStage) = i.stage.map(Json.toJson(_))
     def roleList = summary[Instance](prismDataStore.instanceAgent, i => i.role.map(Json.toJson(_)), "roles")

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -31,6 +31,9 @@ class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
   val reservationAgent = new CollectorAgent[Reservation](new ReservationCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val rdsAgent = new CollectorAgent[Rds](new RdsCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val vpcAgent = new CollectorAgent[Vpc](new VpcCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
+  val cloudformationStackAgent = new CollectorAgent[CloudformationStack](new CloudformationStackCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
+
   val allAgents = Seq(instanceAgent, lambdaAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
-    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent, vpcAgent)
+    serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent,
+    vpcAgent, cloudformationStackAgent)
 }

--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -71,6 +71,12 @@ object model {
   implicit val subnetWriter: Writes[Subnet] = Json.writes[Subnet]
   implicit val vpcWriter: Writes[Vpc] = Json.writes[Vpc]
 
+  implicit val cloudformationStackDriftInformationWriter: Writes[CloudformationStackDriftInformation] = Json.writes[CloudformationStackDriftInformation]
+  implicit val cloudformationStackOutput: Writes[CloudformationStackOutput] = Json.writes[CloudformationStackOutput]
+  implicit val cloudformationStackParameter: Writes[CloudformationStackParameter] = Json.writes[CloudformationStackParameter]
+  implicit val cloudformationStackResource: Writes[CloudformationStackResource] = Json.writes[CloudformationStackResource]
+  implicit val cloudformationStackWriter: Writes[CloudformationStack] = Json.writes[CloudformationStack]
+
   implicit val loadBalancerWriter: Writes[LoadBalancer] = Json.writes[LoadBalancer]
 
   implicit val awsAccountWrites = Json.writes[AWSAccount]

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "route53" % awsVersion,
       "software.amazon.awssdk" % "iam" % awsVersion,
       "software.amazon.awssdk" % "rds" % awsVersion,
+      "software.amazon.awssdk" % "cloudformation" % awsVersion,
       "com.beust" % "jcommander" % "1.75", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommanderbu
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersionOne,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersionOne,

--- a/cdk/lib/__snapshots__/prism-access.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-access.test.ts.snap
@@ -51,6 +51,8 @@ Object {
                 "lambda:ListFunctions",
                 "lambda:ListTags",
                 "rds:Describe*",
+                "cloudformation:Describe*",
+                "cloudformation:Get*",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/cdk/lib/prism-access.ts
+++ b/cdk/lib/prism-access.ts
@@ -59,6 +59,8 @@ export class PrismAccess extends GuStack {
             "lambda:ListFunctions",
             "lambda:ListTags",
             "rds:Describe*",
+            "cloudformation:Describe*",
+            "cloudformation:Get*",
           ],
         }),
       ],

--- a/conf/routes
+++ b/conf/routes
@@ -64,6 +64,10 @@ GET        /rds-instances/:arn                controllers.Api.rds(arn)
 GET        /vpcs                              controllers.Api.vpcList
 GET        /vpcs/:arn                         controllers.Api.vpcs(arn)
 
+GET        /cloudformationStacks              controllers.Api.cloudformationStackList
+GET        /cloudformationStacks/:arn         controllers.Api.cloudformationStack(arn)
+
+
 # Map static resources from the /public folder to the /assets URL path
 
 GET        /assets/*file                      controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
## What does this change?
There is a rich seam of information in the cloudformation stacks. This extracts it every few minutes and makes it available to prism clients. With this we can more easily ask questions about resources that are or are not looked after by cloudformation and identify the stack that a resource belonds to more quickly.

## How to test
This should be tested in CODE to check that is works as expected and doesn't reveal private data.

## How can we measure success?
 - Being able to identify all S3 buckets not created in Cloudformation.
 - Being able to identify any CFN stacks that have stack policies

## Have we considered potential risks?
There are a few risks worth a little more thinking about:
 - will the extra data make prism too slow again?
 - is any of the data in outputs and parameters for stacks be private?