### PR TITLE
Add ability to filter by existence of fields

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -318,7 +318,7 @@ object Api extends Status {
       }
     }
 
-  def itemJson[T<:IndexedItem](item: T, expand: Boolean = false, label: Option[Label] = None, filter: Matchable[JsValue] = ResourceFilter.all)(implicit request: RequestHeader, writes: Writes[T]): Option[JsValue] = {
+  def itemJson[T<:IndexedItem](item: T, expand: Boolean = false, label: Option[Label] = None, filter: Matchable = ResourceFilter.all)(implicit request: RequestHeader, writes: Writes[T]): Option[JsValue] = {
     val json = Json.toJson(item).as[JsObject] ++ Json.obj("meta"-> Json.obj("href" -> item.call.absoluteURL(), "origin" -> label.map(_.origin)))
     if (filter.isMatch(json)) {
       val filtered = if (expand) json else JsObject(json.fields.filter(List("arn") contains _._1))

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -43,6 +43,8 @@
             <tr><td><code>stage!=TEST</code></td><td>invert - return objects whose stage field does not have the value of TEST</td></tr>
             <tr><td><code>role~=id.*</code></td><td>regexs - return objects whose role field matches the regular expression id.* (i.e. starts with id)</td></tr>
             <tr><td><code>role!~=id.*</code></td><td>inverted regex - return objects whose role field does not match the regular expression</td></tr>
+            <tr><td><code>tags.Name=</code></td><td>existence (when value is empty) - return objects whose <code>tags.Name</code> field exists in the output</td></tr>
+            <tr><td><code>tags.Name!=</code></td><td>inverted existence - return objects whose <code>tags.Name</code> field does not exist</td></tr>
             <tr><td><code>stage=TEST&role~=id.*</code></td><td>multiple fields - an exact match of stage and a regex match of role; this returns objects whose stage field has value of TEST <strong>AND</strong> whose role field matches the regular expression</td></tr>
             <tr><td><code>stage=TEST&stage=CODE&nbsp;&nbsp;</code></td><td>fields can be specified twice - here we return objects whose stage field has the value of TEST <strong>OR</strong> CODE</td></tr>
             <tr><td><code>stage!=TEST&stage!=CODE&nbsp;&nbsp;</code></td><td><strong>this makes no sense</strong> - here we return objects whose stage field has a value that is not TEST <strong>OR</strong> not CODE (i.e. all objects)</td></tr>


### PR DESCRIPTION
## What does this change?
One of the queries that was impossible to do without leaning on `jq` was to find records where a field was not defined. This was mainly down to weird logic where the inversion was done after the type of value was discovered and any time the valuewas null we would never match the object regardless of any filters. This improves that situation by rearranging the structure of the logic so inversion is done before the type of value is assessed.

This also fixes a longstanding issue with not being able to search on boolean fields for the same reason as above.

## How to test
There are new tests added but you can test with any boolean fields or by doing existance queries. For example: `https://prism.gutools.co.uk/lambdas?runtime!=` now works as you might expect.

## How can we measure success?
Easier to identify resources by wider criteria.

## Have we considered potential risks?
It's possible that existing corner case behaviour has changed a little which might break assumptions used elsewhere in consumers of Prism. This is worth watching for and rolling back if need be. Most likely riff-raff or amiable.