### PR TITLE
Extend ASG healthcheck grace period

### DIFF
--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -120,7 +120,7 @@ Object {
     },
     "AutoscalingGroup": Object {
       "Properties": Object {
-        "HealthCheckGracePeriod": 500,
+        "HealthCheckGracePeriod": 600,
         "HealthCheckType": "ELB",
         "LaunchConfigurationName": Object {
           "Ref": "AutoscalingGroupPrismLaunchConfig69D33207",

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -87,7 +87,7 @@ export class PrismStack extends GuStack {
         },
       },
       healthCheck: HealthCheck.elb({
-        grace: Duration.seconds(500),
+        grace: Duration.seconds(600),
       }),
       additionalSecurityGroups: [appServerSecurityGroup],
       blockDevices: [


### PR DESCRIPTION
## What does this change?

We have recently had [problems](https://riffraff.gutools.co.uk/deployment/history?projectName=tools%3A%3Aprism&stage=PROD&status=Failed&pageSize=20&page=1) bringing new Prism instances into service. The [logs](https://logs.gutools.co.uk/s/devx/goto/b444cf52cb2ea71554007b3d7ce34d9c) from an instance which failed to launch this morning show Prism's initial data collection (which seems to be required for healthchecks to pass) taking longer than the current grace period of 500 seconds.

Consequently, this PR increases the ASG's [health check grace period](https://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html), in an attempt to bring new instances into service more reliably. 

## How to test

I have confirmed that the CFN update doesn't cause any problems/replacements by deploying to `CODE`. We'll only know for sure whether this has been effective after a few `PROD` deploys complete successfully.

## How can we measure success?

Prism deployments should be more reliable.

## Have we considered potential risks?

As Prism continues to collect more data, the start-up crawl is going to take more time. In the longer term we probably need to look at code optimisations (or architecture changes) rather than continuing to increase this grace period, but hopefully this can keep us moving in the short-term.