### PR TITLE
Increase ASG healthcheck grace period (again)

### DIFF
--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -120,7 +120,7 @@ Object {
     },
     "AutoscalingGroup": Object {
       "Properties": Object {
-        "HealthCheckGracePeriod": 600,
+        "HealthCheckGracePeriod": 800,
         "HealthCheckType": "ELB",
         "LaunchConfigurationName": Object {
           "Ref": "AutoscalingGroupPrismLaunchConfig69D33207",

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -87,7 +87,7 @@ export class PrismStack extends GuStack {
         },
       },
       healthCheck: HealthCheck.elb({
-        grace: Duration.seconds(600),
+        grace: Duration.seconds(800),
       }),
       additionalSecurityGroups: [appServerSecurityGroup],
       blockDevices: [


### PR DESCRIPTION
This is a more generous version of https://github.com/guardian/prism/pull/226, as 600 seconds still doesn't seem to be sufficient! This [dashboard](https://logs.gutools.co.uk/s/devx/goto/62844fe86e35160bcb41ebcfa1ebd44a) suggests that 800 seconds should be OK.