### PR TITLE
Disable CFN crawling

### DIFF
--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -31,9 +31,13 @@ class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
   val reservationAgent = new CollectorAgent[Reservation](new ReservationCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val rdsAgent = new CollectorAgent[Rds](new RdsCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val vpcAgent = new CollectorAgent[Vpc](new VpcCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
+
+  // We do not currently start this agent because it causes us to hit AWS rate limits.
+  // Ultimately, this prevents new instances from coming into service reliably.
+  // To re-enable this functionality, add cloudformationStackAgent to allAgents.
   val cloudformationStackAgent = new CollectorAgent[CloudformationStack](new CloudformationStackCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
 
   val allAgents = Seq(instanceAgent, lambdaAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
     serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent,
-    vpcAgent, cloudformationStackAgent)
+    vpcAgent)
 }


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/prism/pull/197 added new functionality for crawling CloudFormation stacks and resources.

Unfortunately, we are regularly seeing rate limiting from AWS related to this functionality and this has made `PROD` deployment extremely unreliable. If I understand correctly, AWS request quotas are implemented at the account-level, which means that this rate limiting may also interfere with other functionality which relies on this quota (e.g. Riff-Raff's CFN deployment type).

I have experimented with a change which reduces the number of calls made to AWS (by dropping the policy information), but unfortunately this is still not sufficient to avoid the rate limiting. 

Consequently, this PR disables the CFN crawling in an attempt to stabilise things again. Obviously we will need to think of a better solution for this in the long-term (possibly crawling CFN via a single process e.g. a lambda and writing results to S3), but this is a non-trivial piece of work. Another short-term alternative would be to raise support requests asking for a quota increase across all of our accounts.

I've deliberately left most of the code in place to make re-enabling this functionality (for experiments, or one-off pieces of research) trivial. This approach has some downsides (see risks section).

## How to test

* I've deployed this to `CODE` to confirm that healthchecks still pass

## How can we measure success?

* Deployment of this project becomes reliable again

## Have we considered potential risks?

* There's a small risk that someone has already started using this functionality and we are breaking it for them (I think this is very unlikely)
* We are losing some useful functionality
* The way that I've removed this collector means that the routes are still visible/reachable, so anyone who does try to use this may be confused about the responses
* We still have a lot of (soon to be unused) code in our repo, so there's a risk that this will be forgotten about and slow us down over time
