### PR TITLE
Upgrade @guardian/cdk to v19.2.1

### DIFF
--- a/cdk/lib/prism-access.ts
+++ b/cdk/lib/prism-access.ts
@@ -32,7 +32,10 @@ export class PrismAccess extends GuStack {
      * This is the external prism role in each account which is used by prism to crawl data from that account.
      */
     const prismRole = new GuRole(this, "PrismRole", {
-      existingLogicalId: "PrismRole", // we override this to ensure that we do not replace the existing resource
+      existingLogicalId: {
+        logicalId: "PrismRole",
+        reason: "We override this to ensure that we do not replace the existing resource",
+      },
       description: "Role Prism uses to crawl resources in this account",
       assumedBy: new ArnPrincipal(parameters.PrismAccount.valueAsString),
     });

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -77,7 +77,8 @@ export class PrismStack extends GuStack {
       ...PrismStack.app,
       existingLogicalId: {
         logicalId: "AutoscalingGroup",
-        reason: "We override this to ensure that we do not replace the existing resource",
+        reason:
+          "We override this to ensure that we do not replace the existing resource (as this may result in downtime)",
       },
       vpc,
       vpcSubnets: { subnets },

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -4,7 +4,6 @@ import type { App } from "@aws-cdk/core";
 import { Duration } from "@aws-cdk/core";
 import { Stage } from "@guardian/cdk/lib/constants";
 import { GuAutoScalingGroup, GuUserData } from "@guardian/cdk/lib/constructs/autoscaling";
-import { GuDistributionBucketParameter } from "@guardian/cdk/lib/constructs/core";
 import { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core/stack";
 import { GuStack } from "@guardian/cdk/lib/constructs/core/stack";
@@ -58,7 +57,11 @@ export class PrismStack extends GuStack {
       description: "application servers",
       vpc,
       allowAllOutbound: true,
-      existingLogicalId: "AppServerSecurityGroup",
+      existingLogicalId: {
+        logicalId: "AppServerSecurityGroup",
+        reason:
+          "We override this to ensure that we do not replace the existing resource (security group replacement is painful!)",
+      },
       ...PrismStack.app,
     });
 
@@ -72,7 +75,10 @@ export class PrismStack extends GuStack {
 
     const asg = new GuAutoScalingGroup(this, "AutoscalingGroup", {
       ...PrismStack.app,
-      existingLogicalId: "AutoscalingGroup",
+      existingLogicalId: {
+        logicalId: "AutoscalingGroup",
+        reason: "We override this to ensure that we do not replace the existing resource",
+      },
       vpc,
       vpcSubnets: { subnets },
       role: role,
@@ -114,7 +120,11 @@ export class PrismStack extends GuStack {
       listener: {
         allowConnectionsFrom: [Peer.ipv4("10.0.0.0/8")],
       },
-      existingLogicalId: "LoadBalancer",
+      existingLogicalId: {
+        logicalId: "LoadBalancer",
+        reason:
+          "We override this to ensure that we do not replace the existing resource (as this would cause downtime)",
+      },
     });
 
     appServerSecurityGroup.connections.allowFrom(loadBalancer, Port.tcp(9000), "Port 9000 LB to fleet");

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.107.0",
-    "@guardian/cdk": "19.0.0",
+    "@guardian/cdk": "19.2.1",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -1044,10 +1044,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@19.0.0":
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.0.0.tgz#5adefed1c06cbd0cdcdbacc3359f6541007697b7"
-  integrity sha512-wBALFvwjByJ/SYtRsv9tyvryFj3iSWYvJAJecxxcIzDbX+zBFKq/IoH1q84cTawdE4DXOZXc2cQuYJp5YGvGfw==
+"@guardian/cdk@19.2.1":
+  version "19.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.2.1.tgz#c89265fb61c47ec2f70f375740e2899f51758497"
+  integrity sha512-c+5w/wxvx8+1+9DorUWqqh+8VY2iIGgjqnZ9FCTrFbFN/l77W6eyv8tA9Qx1C7uWpPGWG+x3/hwfL8tCK/6gtA==
   dependencies:
     "@aws-cdk/assert" "1.107.0"
     "@aws-cdk/aws-apigateway" "1.107.0"
@@ -1064,8 +1064,8 @@
     "@aws-cdk/aws-rds" "1.107.0"
     "@aws-cdk/aws-s3" "1.107.0"
     "@aws-cdk/core" "1.107.0"
-    aws-sdk "^2.919.0"
-    execa "^5.0.1"
+    aws-sdk "^2.929.0"
+    execa "^5.1.1"
     git-url-parse "^11.4.4"
     read-pkg-up "7.0.1"
 
@@ -1793,10 +1793,10 @@ aws-sdk@^2.848.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.919.0:
-  version "2.922.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.922.0.tgz#4568be067dceaaeda5d2d5a7e2f22666687f0b32"
-  integrity sha512-SufbR5TTCK94Zk/xIv4v/m0MM9z+KW999XnjXOyNWGFGHP9/FArjtHtq69+a3KpohYBR1dBj8wUhVjbClmQIBA==
+aws-sdk@^2.929.0:
+  version "2.933.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.933.0.tgz#42f2cab2ebb63291ce6e764510e8bfa997847256"
+  integrity sha512-WJBQSE3zdX5YbzTa5+k45hzUAL5EPyiZJAnzCV6TIkPEYPMY215q8iloBATqbntbvAyWC4j2Rto6+RYmki1MOQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2785,7 +2785,7 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^5.0.1:
+execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
## What does this change?

Upgrades to use @guardian/cdk to v19.2.1. We are already on v19.0.0, so the changes here are minimal. The primary motivation for this is to pick up https://github.com/guardian/cdk/pull/609, which is required for the migration to the EC2 App Pattern.

## How to test

The snapshot tests show that the generated template is unchanged. This should be sufficient.

## How can we measure success?

We will need to make fewer changes in the EC2 App Pattern migration PR(s).

## Have we considered potential risks?

This seems very low risk to me.