### PR TITLE
Add buckets to the list of things Prism knows about

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prism collects data on the following entities:
  - Stages
  - Stacks
  - Apps
+ - Buckets
 
 Endpoints
 ---------


### PR DESCRIPTION
## What does this change?

Adds buckets to the list of things Prism knows about. Perhaps we could also add paths for the various resources?
