### PR TITLE
Update to cdk version 21.0.0

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,13 +15,13 @@
     "generate": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.107.0",
+    "@aws-cdk/assert": "1.110.1",
     "@guardian/eslint-config-typescript": "^0.5.0",
     "@types/jest": "^26.0.23",
     "@types/node": "15.6.2",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
-    "aws-cdk": "1.107.0",
+    "aws-cdk": "1.110.1",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
@@ -34,8 +34,8 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.107.0",
-    "@guardian/cdk": "19.2.1",
+    "@aws-cdk/core": "1.110.1",
+    "@guardian/cdk": "21.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2,697 +2,709 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.107.0.tgz#dd4798d1e92414662b38bfd088d65ce9b02a90e1"
-  integrity sha512-tV+Nbvb3DOvZpgrLEYFoG4lsMk2zddtPSGDVdWN4A5xaIhYFcnh27+l2//2IuBlV9RSmeLAYPZtJV6Zn7nLegg==
+"@aws-cdk/assert@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.110.1.tgz#1f03c0f008e9e41bb2a6eb62599dc2245a06695c"
+  integrity sha512-GdLgThJrOZ4VsvnuJu+uYtbbx884m0jFavy4NgWc7KSE+Vn4X51VtO4Ju02el/pMSgS7MLgbGQXLYuFAlt3ITA==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/cloudformation-diff" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/assets@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.107.0.tgz#e03c39bb4031f418fcae8025b6a770c812cebfd1"
-  integrity sha512-YIN57vqtfXwrOBUvMmIi5r9rEOt2JYvf+5BIbNG3ilMvmFDGl66buAFtAJjdEY95uJl0tPqJqC99VOGHGsY/iQ==
+"@aws-cdk/assets@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.110.1.tgz#e3578c8926e07cfb44c9b02e095b2e1d0c6c8068"
+  integrity sha512-aPJvTQeSkkvS7TjtQmMU1zRRSfhMqgZs9lZGUKv6wc/zeMS1t89ntzvuDCZmpUBP3tZbx0lexLqOAvBgD+FdSQ==
   dependencies:
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-apigateway@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.107.0.tgz#90a6b6732b6c0a1f5c9b217a413bba5a6f2af3c8"
-  integrity sha512-qgVKLwRMkuDgzB6mkqIXjvGfhlgam79JTL0K9XsEpL2K/XEjDSQhyICenmPh0TLjFN/aB9X2qYRaH7BIU3u9wg==
+"@aws-cdk/aws-apigateway@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.110.1.tgz#36a7a6c26651d59942c30a2e0ba2ca65a4af3ad1"
+  integrity sha512-KQQdNIFPD2/hHeGSu6bbbhxW6Dt+GhLWX42TWVQpktBfA36hptYxf7QhX+gjhlthKhjbJSvEMYLG4ZDn9/nVqg==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-cognito" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-s3-assets" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-certificatemanager" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-cognito" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-s3-assets" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-applicationautoscaling@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.107.0.tgz#fbce53a2e7258d7ffc9c57bef6913b6efbd54195"
-  integrity sha512-Qfp+4AOaTsEDkqGRhX1tiZJ0ywZoaClA02hO+R4qOYor+4kwI+lCpdAhwBP2zuChD+1vMmlMox5dpbgI51CnVA==
+"@aws-cdk/aws-applicationautoscaling@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.110.1.tgz#1604cba645454bfb76900f2a73caee422928408e"
+  integrity sha512-tg+JhgShqwRBAP2fZ9mXRbleQQxfT8UsciKbNSX6C7RAzJTD2Esoz384bOHmOdn9B8zgfpBXyx8erkrr1ZMEjg==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-autoscaling-common" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-common@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.107.0.tgz#86cfa6b6a144fd72a85b92f6784200964be60245"
-  integrity sha512-dxAOPIFbzK+R+cJrfNmgsqxE1K9tAlgo9oc9Gruvxxzv1T4EF/aMW7VUGgxIOZkghCkq63QT9xpKSWmlQZdr9w==
+"@aws-cdk/aws-autoscaling-common@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.110.1.tgz#e4889f0b792a1ecfc44bd50b9e6ded5aa30ead0b"
+  integrity sha512-l2IEuiNGbnJWL5CJ/+676N6Oz1wPNc9lReNnHakznT6rZQ6rIFiQ0b6xu7AMH+CtAKXcdhCyv/4nrXhlUjsROQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-hooktargets@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.107.0.tgz#67ed9e7708fcd5da9788736169defb38283054c3"
-  integrity sha512-nE57d6KUlqJGBHqs+QrRomCI4jmqrLd1klIv5hg1K8jHgB5PFd42pkmQYBMMsSrXY9vacT079/DneG+segrkKg==
+"@aws-cdk/aws-autoscaling-hooktargets@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.110.1.tgz#a90badbb3a1278d4386ad8068b06dbd719353f0f"
+  integrity sha512-PBicW8tmvzh6YyYrIdQfqkWT65SfIqnGvKYG5mYS8qY1CBjArve6gDUJ0Wg1Pq0GoZ41e1+JdvHirlG7xh+k8w==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-autoscaling" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/aws-sns-subscriptions" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.107.0.tgz#782668c5216d1c86d9f1bb7a6a6f9f3eb6033fd2"
-  integrity sha512-NmphwpgU7lxTK+8zeN/9XuMnO0T+J8NvTlyH0QcqMbQeuJWFNXwAVwzQmPdmf7Bf/88xTUohP2RgH2MvLCGMBQ==
+"@aws-cdk/aws-autoscaling@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.110.1.tgz#4dbdfb971efef3001d604fc2966c7df80a5b3792"
+  integrity sha512-fHjEaYJ0+gjSLNU49nm2qOAvsyFGNa/rVceH/FFjdZoquasnoa1Zms5fyTpin/o68lHvpcxozplDTt4txanCpA==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-autoscaling-common" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-certificatemanager@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.107.0.tgz#442e87afcecfc382d86ec99d7760743ccc26aa6f"
-  integrity sha512-pMeCF4CUOT0Zor7gbZF5NT54Fn50b+bTSXYTRzM9v8nXlIFpo3HJAsIpVJRGNnDdLwwEXXmRzgx7dIE4UVzouw==
+"@aws-cdk/aws-certificatemanager@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.110.1.tgz#d689521aadeeba95d32e322f62aac0f44e5e039a"
+  integrity sha512-LppbCL/KIKDlefIRXV2vpkoNwUFW2+b6nYMHDnL54eWn2T3vNkiGPcNh79q5DnoD6o2OJGEHorlbud86STIP9A==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-route53" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-route53" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudformation@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.107.0.tgz#50e7b960d9f03def9806cea8f2d268c5e5ebcd2e"
-  integrity sha512-n38WuGnt1vxJaKxqwALCZndlHoiO7tKD5tvI3AmEHGYt+IAjLl5cu37qVtqfNKqs9uo4cUXPrIfSMRb3/0d5CQ==
+"@aws-cdk/aws-cloudformation@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.110.1.tgz#ca17aa35eac169b48d4e8f6d5d8a669509d94e73"
+  integrity sha512-lX+UG8jXd490J+UzDiFj35FGA6niATwgVjioCutdtwFDEDqf7xGA09+Eueh/55TinL4tOB0vwsxnsMc9b2J/qg==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudfront@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.107.0.tgz#51899464f137e43bdc134c2eaf6c4cf95dc8e837"
-  integrity sha512-92TRtZN46sQt4G8vTx7dPcUaUlLg0bLdnXSFErc2Rt0SybGPFMebu//woW79bGqYbU6Mpy0kerT3Ghk2tyizdA==
+"@aws-cdk/aws-cloudfront@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.110.1.tgz#2c67c7c6eaa3fafd93606f1309322dd288ed154d"
+  integrity sha512-rpNjXM2iL3FQjaI7glqo9KkoqZtywlXrSWkuR0Chve//DGcqD3l/+S466eRYJFQ3CyId/jTYYP9HbFsCnnsHOg==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-ssm" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-certificatemanager" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-ssm" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch-actions@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.107.0.tgz#07c3a1324f0ee15ce903e3849990e320fff0dc52"
-  integrity sha512-rkGWRmsDHlddXaOB903CXwxl8ILx7p2B21zJewVvk/wt9IQ4rbtczrAxFjjgi5491DfsXmQHKcbIJ0/xE6SfsA==
+"@aws-cdk/aws-cloudwatch-actions@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.110.1.tgz#adbecf92f7bd366bc6ce9ff439bea806ebf4a3c1"
+  integrity sha512-ilpMlpT+O4YS1qY9tImjkQfcpqqc/RnLMyRWr4hU2PHk/5SkVTwckSS8vX0U6+E2yKC0ih7N9hcTBVJYHcbEZA==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.107.0"
-    "@aws-cdk/aws-autoscaling" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
+    "@aws-cdk/aws-autoscaling" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.107.0.tgz#c75addf146edca6d01a74c839de19b6b08dc5e1f"
-  integrity sha512-jyq7COuuqwUJS4gMmC7jKlI9+nTOnUgv2t7Ca7QHgPj8sTdZ5YJFfqEvscYXUCmib4PsKO8aZhvB/BD6x7bGWw==
+"@aws-cdk/aws-cloudwatch@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.110.1.tgz#732c04bc0949d6e2a4db5e697cbd722726b83eed"
+  integrity sha512-zrkKkdrvZw5uImMb7iFVkThJHCnRFxKrm+evbVCtVhSXrcS9tHYG65mTGSc0DkwPoVyfJZHLTzOWQnE6sVi9MA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codebuild@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.107.0.tgz#5103a1ef0364611bdbec3f23f2097472fa4e5ebe"
-  integrity sha512-gaMnTRPpTR7fcODgojDP9RH0vGniaz1wPfTK3oPhAVZfuQqcRrUsUa2zZECnik8mF3LFdd1mwuHtFdvzyPZi8Q==
+"@aws-cdk/aws-codebuild@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.110.1.tgz#5e805dc6482b430812e9ab6531a5b1db7570aa45"
+  integrity sha512-jxt5hrMTblXTr5QBggYLZn4dKFwxrnhxbNb5HGL00c0zu4Ua7Atogh7NfCDWr78BcGpLrjjIMTae6U2bKJDAFw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-codecommit" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-ecr" "1.107.0"
-    "@aws-cdk/aws-ecr-assets" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-s3-assets" "1.107.0"
-    "@aws-cdk/aws-secretsmanager" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-codecommit" "1.110.1"
+    "@aws-cdk/aws-codestarnotifications" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-ecr" "1.110.1"
+    "@aws-cdk/aws-ecr-assets" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-s3-assets" "1.110.1"
+    "@aws-cdk/aws-secretsmanager" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     constructs "^3.3.69"
     yaml "1.10.2"
 
-"@aws-cdk/aws-codecommit@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.107.0.tgz#8231dedc676c93accc9e65d355bbf36974176b1c"
-  integrity sha512-k+KHuJTQ2bJXYmDTLY3V4vRmqzSly9Cf1MgKGFXoYYEOGaOHrMTdiBi3dBnTetOZlgArVI6QIRsRF4MQMmxMfg==
+"@aws-cdk/aws-codecommit@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.110.1.tgz#801cdf6e51c71f54136e8b4ac0168cebeca38e9e"
+  integrity sha512-xbB/Y2xrZs1PmHmP4V561/Dy7aHzJC9on4mQp1WScnRjWT138d1wEdv4wdhK8xeG6geRb9nvkkhjS1GYEyUN/Q==
   dependencies:
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codeguruprofiler@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.107.0.tgz#dcd787e262d4c1c0d05b52b70152d9912140a7d8"
-  integrity sha512-Wi6dTGnoroWJ8nzLucqhLdmE2tMKodaM1n3kmjkDWXkyPiBIp+k0sckrBBTKNXvf/xWwFJzjNH+bUfBxEYTpKg==
+"@aws-cdk/aws-codeguruprofiler@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.110.1.tgz#f650e2fc7a34a1ddeb6d8d96b35f1f1f326fd6ce"
+  integrity sha512-11liIxSsa9Y4YgC7hWapK/ArpKfrkf6cVCLNSgQnCmHM6UZDp3wFNOPeVLEu6PMft+l3Yvmy8F1+NgA6T4Vh2g==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codepipeline@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.107.0.tgz#4e687ae8571c005b321f4c382982e5037a83734b"
-  integrity sha512-wIHpeOmErVsBZPpve1rDclx/e+UpE+CHzpuv9bSveeRmzHl46RhkqzL3zXde/mt99KB3A05Ei7ujKxdJGvXSYw==
+"@aws-cdk/aws-codepipeline@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.110.1.tgz#93650b84b2775877708d12aff97e1a6b721fb926"
+  integrity sha512-6y22/gjidZ0OAbHCOnK+izWBNu0aLenwgGcmIZkkSaJ9To6JDqf1MxdCsKlxxehBjKQ/lc047XKbu+VE2UZUcQ==
   dependencies:
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-codestarnotifications" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cognito@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.107.0.tgz#1167724298e4fdff2c78627b71dc9e6e054967c0"
-  integrity sha512-MSDyvWAn1ey7uIQnwplys11M1Pjz0y/YUJjzkxi2l/4CDnzYB6LDk8vc9VMkMUIoHzaXJf0RFZx1vF8fKM5Gtg==
+"@aws-cdk/aws-codestarnotifications@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.110.1.tgz#49692d9289801d83070ebd9b99ef1b3f7a650090"
+  integrity sha512-LmU61x3OK/UhEEpBcP+oKU6ePqzAtdiUk++xkUNhje4FkdM7OR1laMiskZN5MR4MCFKKgQV7KKNeppPH49c4kg==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/custom-resources" "1.107.0"
+    "@aws-cdk/core" "1.110.1"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-cognito@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.110.1.tgz#8feb7aec536b319da0383fa2b011ddbba8287689"
+  integrity sha512-J7MzpzwN1tUDCTpsHP03qXfUM+MbNuJ/IYz/wWg3fP2RdXKfcGDKVdSl27gEnsCaiC6cmQLzStRWW6ki2x87ow==
+  dependencies:
+    "@aws-cdk/aws-certificatemanager" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/custom-resources" "1.110.1"
     constructs "^3.3.69"
     punycode "^2.1.1"
 
-"@aws-cdk/aws-dynamodb@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.107.0.tgz#77352206a1010e893863904a4cf455db846e4eb3"
-  integrity sha512-mNVATiKGjXHwtiB8034SBdd03i5josSAg3Ouoeh4arY2OLVciFxpvd/kL5wnBe/BY31QY9Pn6q6WA2+USTJAdw==
+"@aws-cdk/aws-dynamodb@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.110.1.tgz#ad8ad6b69a3a044557bddcc01d844f5ab8d4b4b3"
+  integrity sha512-DJ26oXT8Ib7N/ylWyWeZF6QHdqvjMyzcz3dcHZacEQZGqj0aBOVXQtmcZAb+qDBNsg81eKJE4E/3Qsy1YT2qJA==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/custom-resources" "1.107.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kinesis" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/custom-resources" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ec2@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.107.0.tgz#c91f4b7db381a5231c2666a80bc59f48c199fba9"
-  integrity sha512-9+w6jEJJBD8U4S/OK7T67+OWFMyCCZA5XKZY3QRZjSEWizvf3dNmn2CW16l/tosJqxPFPYTJhGR0e9x7r+EEvA==
+"@aws-cdk/aws-ec2@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.110.1.tgz#c97bf65f9659ee5101761c9c2748a5786aebfbd4"
+  integrity sha512-lVkWfoVBEXotdhXbYH+DxlVLGVjasBu4rD2FxgjZJe2E+w9atJVgaMUmSuLcVgwLEOVlnYpQ+ffNu+AR/KSziw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-s3-assets" "1.107.0"
-    "@aws-cdk/aws-ssm" "1.107.0"
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-s3-assets" "1.110.1"
+    "@aws-cdk/aws-ssm" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecr-assets@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.107.0.tgz#0da7ad084fd9ee3d15a696c56d0c106f35d3927b"
-  integrity sha512-HFNmW12ow1FzBVdSmA76niV3lxOaowLPoS1LGRcRHTmMECZy6IpLPpY6oLK6UTvJnFWkVWtpyEnN+u6noz0w2A==
+"@aws-cdk/aws-ecr-assets@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.110.1.tgz#ff74319577db8723e46da6b4a4f39c56c5299ec7"
+  integrity sha512-lQJU/BGrnzYKGi+mWALtGPk4jliaVeErlZKi4JXLQi58tr8wzRWjUATqasRh8sU7R/UXmNfmBgN2TL3jwf/57g==
   dependencies:
-    "@aws-cdk/assets" "1.107.0"
-    "@aws-cdk/aws-ecr" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/assets" "1.110.1"
+    "@aws-cdk/aws-ecr" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-ecr@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.107.0.tgz#ada442655fef77106c25e7d7fb14aabea87fbe39"
-  integrity sha512-CEalCKxFAIt2r50j0TdoFpOFt2EuV2dzUH6YLUCW8ywLva7RBH1wR/TlnPnqapQZqZM6ouwLQFnRgc88MTLONw==
+"@aws-cdk/aws-ecr@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.110.1.tgz#9ad40ef09eaf85cac437b1f5de43bd6217248f9e"
+  integrity sha512-m9OHq/0I2V3hDf6O4hwENgk0s0pj0OSxTQK0FuI4iahPt7ALBmIgH3uw7zNtuE6lx2DC7Ge2N3PAl6i9YjXohA==
   dependencies:
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecs@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.107.0.tgz#3f73cd214d971ee3531b2a7f45dae8dd99f6fd28"
-  integrity sha512-3e4y6K1ByiS3tpwNazJxyaK1WLsL5KZoxwL9ANI+aZG/UYLAU0i713CjSjnK28ms20Pp6vdz3HveOM2Kz7KHWQ==
+"@aws-cdk/aws-ecs@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.110.1.tgz#55df6247489996c55aeb162d81b6992c0b5325ba"
+  integrity sha512-bPVpesIXMkzLkYPPUSPDsWj3Op8BME/0le1g+RKB1OZIjkO8et6x6Znrn6mKkFS0FwHsgKqWoSRvKmjponNlTw==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.107.0"
-    "@aws-cdk/aws-autoscaling" "1.107.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.107.0"
-    "@aws-cdk/aws-certificatemanager" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-ecr" "1.107.0"
-    "@aws-cdk/aws-ecr-assets" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-route53" "1.107.0"
-    "@aws-cdk/aws-route53-targets" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-s3-assets" "1.107.0"
-    "@aws-cdk/aws-secretsmanager" "1.107.0"
-    "@aws-cdk/aws-servicediscovery" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/aws-ssm" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
+    "@aws-cdk/aws-autoscaling" "1.110.1"
+    "@aws-cdk/aws-autoscaling-hooktargets" "1.110.1"
+    "@aws-cdk/aws-certificatemanager" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-ecr" "1.110.1"
+    "@aws-cdk/aws-ecr-assets" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-route53" "1.110.1"
+    "@aws-cdk/aws-route53-targets" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-s3-assets" "1.110.1"
+    "@aws-cdk/aws-secretsmanager" "1.110.1"
+    "@aws-cdk/aws-servicediscovery" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/aws-ssm" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-efs@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.107.0.tgz#d484ef7867174b948fab5758076c45dc4647a67a"
-  integrity sha512-hrXsi5hZFYSp0PQr9V4UFBuFwLqMqupbpODJ79rhqBnvSzihd24h/njljyNIWT1ryoZjRhsCvYZu4xJXgoT5Lg==
+"@aws-cdk/aws-efs@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.110.1.tgz#9419ffc9346bc094d5d83e3c727ae44147fb7ed2"
+  integrity sha512-Ly7Acu/ibLpWR+5vxiFzJggIgFG3k7ik7eufpp1bhMMRMRSChiZdabdlVMEsdP9CcK5p66KnyMisHuUqZ+3Hag==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancing@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.107.0.tgz#b57ed99cdf4e8b497aafb7c2eea516502a46cab2"
-  integrity sha512-lQd6N82e52JviMhJXcI0/q8LJmMtlg3Z9Pk+cdGxi3fj5bWIOLYqWb0SPCQbm/0jkCI9BCD71suwxj04kMiI4g==
+"@aws-cdk/aws-elasticloadbalancing@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.110.1.tgz#b0733f9ddcc71e3c4e5001d0d7520e017c86ce6f"
+  integrity sha512-4n7mPXeZQlVF1DXVR4nv9jrHjUUfeVYqRmLlrqGE17uR1wyDraEGz9x7BGA/KpaJ59HpXKdpbtF/XtL5CHRpOw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancingv2@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.107.0.tgz#4a827ca33720e0662a249635f1d654b33e77d76c"
-  integrity sha512-j1XhQvywQGvgRpTGpdMQHRcS0USWwTvp9/B39h0ehUBbyV7jzONDd2h6Pvq9De0NHfLMPJsDTXLg116XYYI+8w==
+"@aws-cdk/aws-elasticloadbalancingv2@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.110.1.tgz#b576856497473d3b7f99e41a24230078fa75f1c1"
+  integrity sha512-ufVqQec/Z4lBXiA8W09g/5KuxTXUehcFYiwK+6ICDEtTEB0iJfejuNM9TNLEfnRuiVhR3x4j3dQOmw99eq858Q==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/aws-certificatemanager" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events-targets@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.107.0.tgz#fbf0a53e9eb712d43db3afced5ff30c210080af8"
-  integrity sha512-PPuW/DdrV0PEfAGu9CRFEnGoulU2DBrC86XZb+nmA29ReVbWIFsMWiHbkhf93WYFdp6ieQUOlfeHA2N80b2FpQ==
+"@aws-cdk/aws-events-targets@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.110.1.tgz#f407dd67bbb8d74c5ef00e6272cbe18ba5b7147c"
+  integrity sha512-71sYjOJv3bSaYdoTikLfyugwL9r/UOk5LXwt8kVTIj+5Eko5bRWShx6gTjjb/Y4u6Ln4sW51RGMUgYnINJcFxA==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.107.0"
-    "@aws-cdk/aws-codebuild" "1.107.0"
-    "@aws-cdk/aws-codepipeline" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-ecs" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kinesis" "1.107.0"
-    "@aws-cdk/aws-kinesisfirehose" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/aws-stepfunctions" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/custom-resources" "1.107.0"
+    "@aws-cdk/aws-apigateway" "1.110.1"
+    "@aws-cdk/aws-codebuild" "1.110.1"
+    "@aws-cdk/aws-codepipeline" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-ecs" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kinesis" "1.110.1"
+    "@aws-cdk/aws-kinesisfirehose" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/aws-sns-subscriptions" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/aws-stepfunctions" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/custom-resources" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.107.0.tgz#a3437d292d793ff9b638b009a3b7bcd35c1b6925"
-  integrity sha512-TRFuVYNbZmECPBKGO9SiAV3r0K7H4AQPEUuw3Uo34QCNPgkXMdBmjVjYIh1I9Q3TI9zC0zWsp8npKyp8raqBcA==
+"@aws-cdk/aws-events@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.110.1.tgz#0286bc4720fd73fa7ca6fdfec6519c9b4ab38ed8"
+  integrity sha512-e8jqWZUUqOowvUtbWB4NO+zsiVQBEMbqMobnYFhKFtVXnM5y0jz1ulzvkqhm/w6uEHoCIDwKM4/PPQv8YtwXyA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-globalaccelerator@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.107.0.tgz#15b18de65cb278e8e35b02002b4c5b728e2808ca"
-  integrity sha512-mfARBd1HVA4q9Rq+bOFYrL11n8V3Dsy9mncAynuems6WN1+goF3rkWOSTYq69QtMWj4xkH9LtThs4f366WaSXg==
+"@aws-cdk/aws-globalaccelerator@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.110.1.tgz#cc6eb6e7a379f408da0a8acb587ead3bb6e6b056"
+  integrity sha512-luFx83BBDbI5yY7CZPPmO7INnFxu1qMJNrLlzYmF1qceEK5FFtxwBq6NeoyEDXGwjoFrNFo21vYfFz8VGvOlkw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/custom-resources" "1.107.0"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/custom-resources" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-iam@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.107.0.tgz#7ab84fb9ab133599aaaa6f041009d4177b1c55b0"
-  integrity sha512-ZSULS+IdMK82VjcxNyLATlnYN1bQVD1om8MXGYxAkFuQLb3XL+uAa7NLVeHZtEKkPYqr8BcYlCXpB1JvGImJkA==
+"@aws-cdk/aws-iam@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.110.1.tgz#3916fb431194afaeef551acd4bb7386e40149670"
+  integrity sha512-qwhVd1ZUeIIMAUqfZjSB5OfVxe0vr9b+eUW/znuL5QjkSMeVORJW5/OEbI2id1OdnncTczyqo9GSJSIX1ISkcg==
   dependencies:
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesis@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.107.0.tgz#6ee2dec4b2f4fefd4a4befe4ca84c31c9831774a"
-  integrity sha512-ubWyaLmqK54WZvMUUgvMJ+AsRKzX7EG5xjvnoj5wYvN9bILeXUKV/I3yHMU47WluKKaDOk12wbUANK2H+sbwZg==
+"@aws-cdk/aws-kinesis@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.110.1.tgz#b47c0d58c9c50395236a56bbd6c8c334bf9ab001"
+  integrity sha512-VajcO/1TmOGRv+NSqr4bNT5agEppNptKnSMCBw78hryXliwUBcehsvtXF4c9zYREOoY1JEhPlvpTZOVdhm2PoA==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesisfirehose@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.107.0.tgz#650c97f9c30c2549b8c6fb9bd227d7dde2b38cca"
-  integrity sha512-Pccnj7M1HSeLRsMYnnSULwYw1rPtDegqPhAoj8bDRIJMZ3/vtfeGaq6wpPd4X1eP8GtvvbRtqbQkw6w3DKYMJg==
+"@aws-cdk/aws-kinesisfirehose@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.110.1.tgz#e3feaf0f87e4143521de52a2e8039e4236eacd18"
+  integrity sha512-If/fWeH72sQL80VTbQBy3qiOMw21XnQJXdSu5odwSx7EyFN0gRurLmjxUq1OlIjTz9tpn+flOBjCvq1OnmBlgQ==
   dependencies:
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kms@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.107.0.tgz#cbb02df718a59bbf8ecba2dbbf60b00e6d09404f"
-  integrity sha512-+b1j/GOeHh76lG92vRhPiyriW96e4TiZ9XVXv5sxv4zJkGD+X5oBVL82RouYJ2gw/onGiiWsobz8J/R1/h14pA==
+"@aws-cdk/aws-kms@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.110.1.tgz#dede58153ced1c46dc50513f1848bb0d9d5b2d33"
+  integrity sha512-PTkK7iO/RvpRMhb3RdAxXQl/c9xfbXgz/PbuqnpTxwtg2D+WoS2+5XJUr+3UddtUporrriBjhj4NhHkNuaw55w==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda-event-sources@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.107.0.tgz#564fe50fde7787640c0b2e53a6b5c7a27e5e04b3"
-  integrity sha512-Hyrms0s6s22hDJnu4V1S8PgtBa6ai5IcXPOWzHWaM52txsuol56GDLVycd3Li+Y5WPW4xYZ476n9iIc11fChtQ==
+"@aws-cdk/aws-lambda-event-sources@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.110.1.tgz#ee9720b7afa982e7c84208fb404c039bfeaef81d"
+  integrity sha512-TQ4gSuuke3fs4vfrgx0+QTE0NGgC79+gETJ20xupeaNXDN/4ETV9t7xICvg/XdwGGy1wUli9G7SXa40ye+/5og==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.107.0"
-    "@aws-cdk/aws-dynamodb" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kinesis" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-s3-notifications" "1.107.0"
-    "@aws-cdk/aws-secretsmanager" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-apigateway" "1.110.1"
+    "@aws-cdk/aws-dynamodb" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kinesis" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-s3-notifications" "1.110.1"
+    "@aws-cdk/aws-secretsmanager" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/aws-sns-subscriptions" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.107.0.tgz#6264d932a4fbec04fbd9ddcbdb7ee80dc4c554dc"
-  integrity sha512-McoQ3rjFtXDHUaq4ovU/ARwBJgQz3iq2cBogv0zg4g8AMw9doGVZnXjIYNFiCBXCQD1IUAlrLi7YhpXBDnygRA==
+"@aws-cdk/aws-lambda@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.110.1.tgz#84c5685d17e5c38f8578f2d57e052b8d7ef7728e"
+  integrity sha512-y4B8MX6jmAUhpjUTqmHk3pOvB+iH7o0lTcps3qVY6rWzASp3slvVuUxa5vOQvjdZmcK41uyOI1tYlq+gxFDOyA==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.107.0"
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-ecr" "1.107.0"
-    "@aws-cdk/aws-ecr-assets" "1.107.0"
-    "@aws-cdk/aws-efs" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-s3-assets" "1.107.0"
-    "@aws-cdk/aws-signer" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.110.1"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-codeguruprofiler" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-ecr" "1.110.1"
+    "@aws-cdk/aws-ecr-assets" "1.110.1"
+    "@aws-cdk/aws-efs" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-s3-assets" "1.110.1"
+    "@aws-cdk/aws-signer" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-logs@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.107.0.tgz#5a1dd9b2f7a4de9e360c5727eb445ac2dd40bab4"
-  integrity sha512-CNZHb4B2+KSmaIgC4rNFAXs+rlHRt5F4Nen/c2TtP9/E9WVZLz4WpYQWQSbV61mFEWFH0vHbihGxP8/pY44AnA==
+"@aws-cdk/aws-logs@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.110.1.tgz#24c2d458546d2c4ad94228f3ecb8c0be6ef82c50"
+  integrity sha512-unWZUsxVZH4OHvM3j5cefJ5Dz7s/TSXKP5nGycmCMy7aCISbY6MLO3hmUKwoFkRAJpZecJOa4Rn1nCSXwt9B8Q==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-s3-assets" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-s3-assets" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-rds@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.107.0.tgz#75b8c09d535ba05dd9bd98dc528dc0cbff6d2495"
-  integrity sha512-1Qmj63V8bDRh4e++PxHkTUVlIXJAq1aCr4G4dtkLI0imskTCVghduvt+pTEODpYHkRri7DIevxLAE6C0SkP1uQ==
+"@aws-cdk/aws-rds@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.110.1.tgz#caaa2b3dafea3e17e7caaba692527f37f8305f63"
+  integrity sha512-cKsH47kgNF4Hz74urQlI5VpePNN+t2uJw9r0mhilEKwkX6WL1ho7kqe3gH1E7rJx+TfxQX8CAyaJDxKpOIf39A==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-secretsmanager" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-secretsmanager" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53-targets@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.107.0.tgz#6f0c1723557daa900bf396840e6577f17d9c4185"
-  integrity sha512-9NUUZj3fLwz+sKcGS/OplZreuzrkEEuXJBn2+zPUIB5sI1NWsRY+R/rLSKy2PchEYsN66pnLSlRlzqDKfO4pgA==
+"@aws-cdk/aws-route53-targets@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.110.1.tgz#902cbc8baf17725dee8b98fba19312a118bad330"
+  integrity sha512-K+8hwgZRnDXqORFnCzuabFDtXFzBEBdD+XiSogBbmF5DkTwtYZQ3qHMd8yQrdJ3Qq4gOQS35LEu65QVH5LuNhQ==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.107.0"
-    "@aws-cdk/aws-cloudfront" "1.107.0"
-    "@aws-cdk/aws-cognito" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.107.0"
-    "@aws-cdk/aws-globalaccelerator" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-route53" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/aws-apigateway" "1.110.1"
+    "@aws-cdk/aws-cloudfront" "1.110.1"
+    "@aws-cdk/aws-cognito" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
+    "@aws-cdk/aws-globalaccelerator" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-route53" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.107.0.tgz#8bb861f1f956111ac6e208f1e3fa2c8bb297b1f2"
-  integrity sha512-gvWD9VsmZV6m+7Phu4DAGpIPy8hf0rZQJIZhvLuffBpICenlDbiW2eH1h1/3O5d6/SBSYLxQ/NbZX18e/RFDGw==
+"@aws-cdk/aws-route53@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.110.1.tgz#2a74b455578bb07971bd3f8ebdde93a0096e6dc2"
+  integrity sha512-aboSPQot/p5Rurf1C1o4iFZmwarCfOHtoz/eZ38001Ve8JvHkJZffBYhzGYnjS8T7vmGWFNz5xelAp+x4Ge9hQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/custom-resources" "1.107.0"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/custom-resources" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-assets@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.107.0.tgz#fec10793c65ec077c4451837a309ddcf3f9d5c25"
-  integrity sha512-9P4d5ADJr7XxaXdB3G4fMcEjhj7GQM3NDtikchH1XMLje8gz4Eagv6ApaqDkHaRzRe3l9VBeoc6fQHIQlWtSHQ==
+"@aws-cdk/aws-s3-assets@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.110.1.tgz#6a89a8825a1524e8c56edf3c8135ac7bb80342c3"
+  integrity sha512-7ft+00cP1D//2rWvs8KZEWH1/ye9COoeeV5BwNDeidWCS3UQos+l2hJbErN9bDQYzbHvG+GevPUdWTpjo2UI7A==
   dependencies:
-    "@aws-cdk/assets" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/assets" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-notifications@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.107.0.tgz#980304682675f02d5f5ac7a3f05388b2632391ad"
-  integrity sha512-0W9ANUj7Z5I8ZeQq8PLsAosItZSCGjentN6+rm8o9Ao5IVH60VwJUfbuvnLaz4dcRIurt8QK3B5qHieIKvZzpA==
+"@aws-cdk/aws-s3-notifications@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.110.1.tgz#3289a372dee82b0740685951939ac0bfa0d11d9d"
+  integrity sha512-Lj37A+DN4c4jO3nC451c82RQQ0NFFLt62ZdGpwNCoYNwNj7Hpx1aeuSj53i24+a5c9H2aQKvavCNPc28DzCk2w==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.107.0.tgz#54914b5171d44f9f70fed764195bce735ac22b36"
-  integrity sha512-BjH9S+ZlFHoqRDRT/I8m3MFB+80F6mHASMnKHuyXoMfUs8qMos7R8XEJAprx/dMf5EwAMfFYS0IFZH21CpBlxw==
+"@aws-cdk/aws-s3@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.110.1.tgz#d49bdca780dc4b7a7adce4d9dcc0c4933c1788df"
+  integrity sha512-hH/T+wgfriwqG6UEmxT5N9/AEbZiTc6gmpyTlbIhx1u4i9x3Ek/lWYrNcshlaOaYGKaGHcw00frXhudtlIbUsQ==
   dependencies:
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sam@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.107.0.tgz#e010399b14f8043d66827e2820a1323eb0e3a83e"
-  integrity sha512-P1YSJKmWB56p3tRDhXIa1ooFAmBbOenDUQh+QVJRChCewolaXM+pf9+bHveiHtVsur++ZptEzyR4d00DVSFeMQ==
+"@aws-cdk/aws-sam@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.110.1.tgz#f1177ad0a0a38c0ec3c35d0a50901f32623f67fa"
+  integrity sha512-csrtY3yXN6PBODVRVzLH46lI2yIPy4lp0R/UPx19QUF3h8kg3ERNsMiFL6pO5Ew7gZ4snvMIQib7Q29SRVP3oQ==
   dependencies:
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-secretsmanager@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.107.0.tgz#b7c4dec643ed79252027aaf601ec2edfed81bb4f"
-  integrity sha512-Bl2fgAPKXMMcWNlJ+BBrtGLIb+EyF1ybOOb1wfKiofKNl1b/jHrH/g7mani79x5IY0NVa7pBR5IZNqlBm98GkA==
+"@aws-cdk/aws-secretsmanager@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.110.1.tgz#bcd4bfbf429088884afa34115afaa7c78c21ddff"
+  integrity sha512-lE5IrL9O/xEZYhAStyLUwALummi8qEmSMvKMZiUWf+Z2B78wW4vGDz0FBu2feyajvDrlcXh9+hXAY4zyqjjnVg==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-sam" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-sam" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-servicediscovery@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.107.0.tgz#1adbf4b547fa2e635c01c1b86ed6d4727213da21"
-  integrity sha512-o2+oLurX2tEFBbyhAKXe7xboeC5rBaprbDPZWUddlZMZPHuX0KggmV3qUOqMtuiATghOw0xDBGz83AwFc/lXTA==
+"@aws-cdk/aws-servicediscovery@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.110.1.tgz#12f3363c905a4859261089eddabd23adc59fd622"
+  integrity sha512-QaoMxyxomBmvrJ0pICJoXMWQEU30dtCCmzdR0qwNzsBSbjOkf2OrbOfy1qcU0TSb7wdz90KtEUCzHzbBzKz8pg==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.107.0"
-    "@aws-cdk/aws-route53" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
+    "@aws-cdk/aws-route53" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-signer@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.107.0.tgz#46bb82726307d528f4d98d7e6b93f179bec9ac16"
-  integrity sha512-1n23akqOg8osrcPcrzoZybVyA9fgWV/VzFcaSOLTUh3zxrtb5UvKdeIwMLMEaNXoyOb1PsdEwfr+0B7GB5+l3g==
+"@aws-cdk/aws-signer@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.110.1.tgz#9caa1e92c49594ad93b86d05d86c336e4bb8f18b"
+  integrity sha512-eLYvjoQDhI603ArmpFlNNrZ06yhrqqdo6mE45TvQRQALEuNsX/L2qBS4VSJsfsoWN5Vimz722ohIuesSwOy1ZQ==
   dependencies:
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns-subscriptions@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.107.0.tgz#308661c8152c8ebe38226254ff9ef1ad5ec431d3"
-  integrity sha512-6ez7EMXmxip6YxT1JmE9obbF6wzgxCAUGCJkZZQId0jT320CX+oiEdCtxut1MWC2CV6ggLYNSDs+5GJVb030kQ==
+"@aws-cdk/aws-sns-subscriptions@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.110.1.tgz#92cd2e4c3cb2404e55275c316f160dc028826c4b"
+  integrity sha512-a0QMVd6TNtnape0emOqG6WR0h5AGW4zF4qnzw2w1kLysPZAudcEMJbPkpvp3tcEhlWf1W+CxHinCp8Z1LXRqWA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.107.0.tgz#524851b4e3351a2984d76d83d1420eb0247ec2e8"
-  integrity sha512-EjRmqiP+xNbP3tZDOSOw2CtiZ56liaaFuJhccLOJTtfDKxhNN5reUdjlsU7GbteJt0ssSN2u/iU3jRXOFX8KHQ==
+"@aws-cdk/aws-sns@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.110.1.tgz#1fbe3ebd3e7efbed415859674c896255a839324b"
+  integrity sha512-1dxpPWEvBQo5bejMeZXm3xWbQPsoaG33swcdcEjpOXMzdeR72F8b8CA7t/bGtsUdEmcHM7FBDaWjR3Qjj6BMWw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/aws-sqs" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-codestarnotifications" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/aws-sqs" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sqs@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.107.0.tgz#24419abffbae28c23f2ec899b052343929ec6fc0"
-  integrity sha512-dcap+XhKRd/5TGy8GWSlZ+vj5iXDrYrlQROnlW5026bXCQDFvYpBO3VoSY8Pyai3VjHJUEU7DKfpkbjl7rxUpA==
+"@aws-cdk/aws-sqs@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.110.1.tgz#80480342b579de376adb15e3b28be20817ec9eb3"
+  integrity sha512-2XCx2uTeVll5aS3SsjU39k+9gGv1Ig9QhvXOq8VNwCxa4/2QsKkWZzJ1GSLjyBXRFzWcT9pjgcCqfW3ZVtSDUw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ssm@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.107.0.tgz#211e7c4107fe63dff90c36a5f953686ed5a7b193"
-  integrity sha512-nhRLAVt8IxRAiUiTj8V9YsDRkykuwq1QlKvXglgChFkd7wtWx7JSBragp5q8rKsLzCYqqWNJ/Ofd7CQlEQamPQ==
+"@aws-cdk/aws-ssm@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.110.1.tgz#8f0933755a7b23f77f778619be2c0b8905355724"
+  integrity sha512-pcxl64YIdJ5sjybHlp3KWsoEpr4gg7a+JL/mMm0oyz9OobetgDbb8yZIjGV5FHqMvse/pW4pyq0gPZwYHZ9I3Q==
   dependencies:
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kms" "1.107.0"
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kms" "1.110.1"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-stepfunctions@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.107.0.tgz#a06441a48edb331c5e22401efdf59d65e2536ef6"
-  integrity sha512-BxH+DRKLI/5JJZXuUWVrycnscW9I42mZZtiOyiAtEK0Fuuva4fhDt3u9Xn0j+s6Ehc4TG5r5EPC1PG32HzLFXA==
+"@aws-cdk/aws-stepfunctions@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.110.1.tgz#dd4e5f515d705342a257bec5c4a59d781f5587ce"
+  integrity sha512-ST1LFjBT/kJ7RoMeJnjqLLynIe+5XoR0yW8i+vcwn8p056KV/HOBuzPicq7dZNasxbXZVQpQT2JsVm25PEXELw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.107.0"
-    "@aws-cdk/aws-events" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-cloudwatch" "1.110.1"
+    "@aws-cdk/aws-events" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/cfnspec@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.107.0.tgz#f65982733bd791cf120ee15796e90ec4d6e6edf2"
-  integrity sha512-GzA5jyInk8V7cNeUa3DutPnSGLxNezQ2IKZsnYDh8MZnBnZQ/OiRuLm1B5RIJMQpWIFWJzJ4D0Qnez8N0O3+PQ==
+"@aws-cdk/cfnspec@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.110.1.tgz#6bbfd8f55f4fbd1dc2238b321d3053be58e35fd7"
+  integrity sha512-5cSKh20hKEiQUd0IzKn69ns2zwq7MmgeJLdO38Bf5dHf8VEVjfZnCAxho7daUJT0kolQWW9Dr1ZeJau/rFvyXA==
   dependencies:
     md5 "^2.3.0"
 
-"@aws-cdk/cloud-assembly-schema@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.107.0.tgz#df3400f25f434e37e6b722d4b5b802300249ce5f"
-  integrity sha512-z1WdnHrHGR6VF7p7Xv6MAwlr4sCGsFGGRJmk4WmvcFosOclLFKfSsxFE2w5RMmuyxLxdJmarSYF3AKOwm9mHng==
+"@aws-cdk/cloud-assembly-schema@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.110.1.tgz#84736bdd7f7092856b450f8b357a05677cf7c4d2"
+  integrity sha512-rsv6yNhRXkqO8UP0UOzRH60Cx89vGSUKcWSzyvvL9VrTpozYCUBMMuTqhZsmArAv82PYzb1pTDcwUnJKDLhWtQ==
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
 
-"@aws-cdk/cloudformation-diff@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.107.0.tgz#a0f78b3f0c18298942f695709ef3e5032f642685"
-  integrity sha512-/FpJfrLHKNWUKOQ9a0yde42jo2s7+0W3XQnTWal1fN4f1n84KB2xLp/ZSI/7TAhHECQxlQDLtTUciDNuzd9qTg==
+"@aws-cdk/cloudformation-diff@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.110.1.tgz#1442d84ca02c5671423f7fd3bfb8d4126d8656e3"
+  integrity sha512-QaVc4YFBwLzp4uPD6enSNAV5stUvJ6aQ0km9hC2BPR68vc0NAHKX+ZZbJoiKPu/0aXjzrYvEqYw4qRIM0d6RlQ==
   dependencies:
-    "@aws-cdk/cfnspec" "1.107.0"
+    "@aws-cdk/cfnspec" "1.110.1"
     "@types/node" "^10.17.60"
     colors "^1.4.0"
     diff "^5.0.0"
@@ -700,46 +712,46 @@
     string-width "^4.2.2"
     table "^6.7.1"
 
-"@aws-cdk/core@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.107.0.tgz#1c88e0b9b8afb185d49c36647d5eb45b32fd0f7f"
-  integrity sha512-yE0yU341HZWd7ee0SsMOToqz4xC3PoaDerSklxWWdgw3rgVatwP4pqrml5ZOE+q6vhPseESvNRjfZizKc7xK7w==
+"@aws-cdk/core@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.110.1.tgz#7fd6408f3e6c2eee7a7bd3a5b8fc48e407a3804c"
+  integrity sha512-E4+DorhqQ3j0qlz6GZ+v95cXvdsQiuyCjO0yYH5Qk/9X2vaXcJoCrbHYh4+Lx6pbBnAVvFMJXtoNFGoA0m9HpA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     "@balena/dockerignore" "^1.0.2"
     constructs "^3.3.69"
     fs-extra "^9.1.0"
     ignore "^5.1.8"
     minimatch "^3.0.4"
 
-"@aws-cdk/custom-resources@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.107.0.tgz#6a8d500696d6521761b5e07bd06510f03c8e1a86"
-  integrity sha512-VTf1eHmNaKEl/xuf4/wUxikRZecVbp+G+NDzW1rwxvGgWl4itd5aYhIvWeW0jO99d9VyXesrxRmdiA28ahXu7g==
+"@aws-cdk/custom-resources@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.110.1.tgz#0d446296bf21756dd14fd1ade9f7ee56a80b9365"
+  integrity sha512-ZimWriUpcGPtBcrW0o3zPfjLj1mCigI/iF8j0tAC6ou49o8F+i/R/27rlCQnLc0d/1R64hhOiEiEjJ3IU7dZ8w==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-logs" "1.107.0"
-    "@aws-cdk/aws-sns" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
+    "@aws-cdk/aws-cloudformation" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-logs" "1.110.1"
+    "@aws-cdk/aws-sns" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
     constructs "^3.3.69"
 
-"@aws-cdk/cx-api@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.107.0.tgz#c1a4b3d88ac33f9c4125ad51e22fbc686a079c19"
-  integrity sha512-nNfdagY9MVrvvDGPjmdCpBaLGZeMxGAGOOUxFpWbkE7PoDRWcESVf0s2BERsIRLglPEab4eJOQ8PNIBTThSkPQ==
+"@aws-cdk/cx-api@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.110.1.tgz#909ab5d48e6f51b6cfebfefc29868b51dd9e9897"
+  integrity sha512-InY00PETF2wYiRA6SsldsjceIi4uRt5ED0nTNx0fApBr6k4OUfBUV44wUyTm6ZuNzeTU3qxaDKH2APRfiH06yA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
     semver "^7.3.5"
 
-"@aws-cdk/region-info@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.107.0.tgz#bfb36081f6113c0c3d9994d5d7a14b256a761c36"
-  integrity sha512-7ucj+0W+JfGxVyVnsYCCJUr0rBGciOJQq/7fp+Ntp76oTjJTsglC7mGiF3b0Gn65BTiJtPiZayX2L50mlJTPpA==
+"@aws-cdk/region-info@1.110.1":
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.110.1.tgz#27eec01f1db9768bdbbfe2037c3e65d9b372b74f"
+  integrity sha512-sRRTO2qH8kWsh4s62bKTmk9IU8uXYmRJHkOjWo6RUC/W0sv7S6VeB1XHZ7QReDF3woJ/n3oPJzsf/bu33m4l+g==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -1044,29 +1056,29 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@19.2.1":
-  version "19.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-19.2.1.tgz#c89265fb61c47ec2f70f375740e2899f51758497"
-  integrity sha512-c+5w/wxvx8+1+9DorUWqqh+8VY2iIGgjqnZ9FCTrFbFN/l77W6eyv8tA9Qx1C7uWpPGWG+x3/hwfL8tCK/6gtA==
+"@guardian/cdk@21.0.0":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-21.0.0.tgz#724b9c666d5dc7d5111e04a4d1b955bb3cc0551e"
+  integrity sha512-TB/lQpbmGY6VHhcEVfnsAQjMXU6+Xng0Y+YTwh8s/nskVBbv/duqabVItMRxPUNWrUOOIo+mpwDrsBf4rve1zg==
   dependencies:
-    "@aws-cdk/assert" "1.107.0"
-    "@aws-cdk/aws-apigateway" "1.107.0"
-    "@aws-cdk/aws-autoscaling" "1.107.0"
-    "@aws-cdk/aws-cloudwatch-actions" "1.107.0"
-    "@aws-cdk/aws-ec2" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.107.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.107.0"
-    "@aws-cdk/aws-events-targets" "1.107.0"
-    "@aws-cdk/aws-iam" "1.107.0"
-    "@aws-cdk/aws-kinesis" "1.107.0"
-    "@aws-cdk/aws-lambda" "1.107.0"
-    "@aws-cdk/aws-lambda-event-sources" "1.107.0"
-    "@aws-cdk/aws-rds" "1.107.0"
-    "@aws-cdk/aws-s3" "1.107.0"
-    "@aws-cdk/core" "1.107.0"
-    aws-sdk "^2.929.0"
+    "@aws-cdk/assert" "1.110.1"
+    "@aws-cdk/aws-apigateway" "1.110.1"
+    "@aws-cdk/aws-autoscaling" "1.110.1"
+    "@aws-cdk/aws-cloudwatch-actions" "1.110.1"
+    "@aws-cdk/aws-ec2" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancing" "1.110.1"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.110.1"
+    "@aws-cdk/aws-events-targets" "1.110.1"
+    "@aws-cdk/aws-iam" "1.110.1"
+    "@aws-cdk/aws-kinesis" "1.110.1"
+    "@aws-cdk/aws-lambda" "1.110.1"
+    "@aws-cdk/aws-lambda-event-sources" "1.110.1"
+    "@aws-cdk/aws-rds" "1.110.1"
+    "@aws-cdk/aws-s3" "1.110.1"
+    "@aws-cdk/core" "1.110.1"
+    aws-sdk "^2.936.0"
     execa "^5.1.1"
-    git-url-parse "^11.4.4"
+    git-url-parse "^11.5.0"
     read-pkg-up "7.0.1"
 
 "@guardian/eslint-config-typescript@^0.5.0":
@@ -1749,19 +1761,19 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-cdk@1.107.0:
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.107.0.tgz#d4df221e1d10aa4ef4370accc08700d5a90fac48"
-  integrity sha512-OOcmb8cHZ/NGkI/dEE02dZPrrWcpanWfK6JRIxAFB2VoBv49ijFvvTt+S2vuBxboNzBr4Dr4gEIq5SabY9co6w==
+aws-cdk@1.110.1:
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.110.1.tgz#d0b78a66536a6da14fe4e78fd9156a1905d7d0af"
+  integrity sha512-9OZtCcHVUt1xeDutxWZdjOhKelqfFBI7az63rdFgPJxCspg3HxQNrrcqDGMZZ3R/fSeVol/zoZz5wHWB730qLw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/cloudformation-diff" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
-    "@aws-cdk/region-info" "1.107.0"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/cloudformation-diff" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
+    "@aws-cdk/region-info" "1.110.1"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     camelcase "^6.2.0"
-    cdk-assets "1.107.0"
+    cdk-assets "1.110.1"
     colors "^1.4.0"
     decamelize "^5.0.0"
     fs-extra "^9.1.0"
@@ -1793,10 +1805,10 @@ aws-sdk@^2.848.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.929.0:
-  version "2.933.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.933.0.tgz#42f2cab2ebb63291ce6e764510e8bfa997847256"
-  integrity sha512-WJBQSE3zdX5YbzTa5+k45hzUAL5EPyiZJAnzCV6TIkPEYPMY215q8iloBATqbntbvAyWC4j2Rto6+RYmki1MOQ==
+aws-sdk@^2.936.0:
+  version "2.937.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.937.0.tgz#6dce5f72343c89bf06672403af3135397eba0fe7"
+  integrity sha512-Ko5fATHxfHWMVJjS5/7eNEeIZ0Sja3B5f7ZvdyGmyRdUv7JVeppkNmc6cK5jFt/qGxVOK2OZnY/vE6D/INwGiQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2050,16 +2062,17 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-cdk-assets@1.107.0:
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.107.0.tgz#f9b64b4c0c3266a694712a2699d503bfb1584552"
-  integrity sha512-Haqs+k8PDxY1Ppfcwt4paQTuTWlm6ulb3OESQ5aOpkCvpWa3e5TsCoCadAgjpRHDjM7fvUj8vgWx8C1+HQlH3A==
+cdk-assets@1.110.1:
+  version "1.110.1"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.110.1.tgz#103ee721fbde9df9b6776710dab4fa44f62d9912"
+  integrity sha512-Jkp+4q/HBLT+Vd6XH1aaOY+VYkcefLEANQO2XmOgfgj94AJSUPsMJmxDX31QojYGyaEJl51MK79x+LaPxtekuQ==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.107.0"
-    "@aws-cdk/cx-api" "1.107.0"
+    "@aws-cdk/cloud-assembly-schema" "1.110.1"
+    "@aws-cdk/cx-api" "1.110.1"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     glob "^7.1.7"
+    mime "^2.5.2"
     yargs "^16.2.0"
 
 chalk@^2.0.0:
@@ -3140,10 +3153,10 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
-git-url-parse@^11.4.4:
-  version "11.4.4"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.4.4.tgz#5d747debc2469c17bc385719f7d0427802d83d77"
-  integrity sha512-Y4o9o7vQngQDIU9IjyCmRJBin5iYjI5u9ZITnddRZpD7dcCFQj2sL2XuMNbLRE4b4B/4ENPsp2Q8P44fjAZ0Pw==
+git-url-parse@^11.5.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.5.0.tgz#acaaf65239cb1536185b19165a24bbc754b3f764"
+  integrity sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==
   dependencies:
     git-up "^4.0.0"
 
@@ -4463,6 +4476,11 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
   dependencies:
     mime-db "1.45.0"
+
+mime@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
+  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## What does this change?

Updates to `@guardian/cdk` version 21.0.0. We also upgrade `aws-cdk` dependencies to version 1.110.1, in order to [keep up with `@guardian/cdk`](https://github.com/guardian/cdk/pull/644).

This change pulls in internal load balancer support for the EC2 app pattern (added in https://github.com/guardian/cdk/releases/tag/v19.4.0), which is needed for Prism's migration. I'm performing this upgrade in its own PR to keep the migration PR(s) as small and simple as possible.

## How to test

The snapshot tests still pass, which shows that Prism's infrastructure is not changed* by this upgrade.

*except for cdk version tags!

## How can we measure success?

Prism should continue working normally; there should be no noticeable changes.

## Have we considered potential risks?

As the generated CFN is not changing, this should be low risk.
