### PR TITLE
Generate a separate stack for Prism (using cdk pattern)

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,12 +3,18 @@ import "source-map-support/register";
 import { App } from "@aws-cdk/core";
 import { PrismStack } from "../lib/prism";
 import { PrismAccess } from "../lib/prism-access";
+import { PrismEc2App } from "../lib/prism-ec2-app";
 
 const app = new App();
 
 new PrismStack(app, "Prism", {
   description: "Prism - service discovery",
   migratedFromCloudFormation: true,
+  stack: "deploy",
+});
+
+new PrismEc2App(app, "PrismEc2App", {
+  description: "Prism - service discovery",
   stack: "deploy",
 });
 

--- a/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
@@ -1,0 +1,968 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The PrismEc2App stack matches the snapshot 1`] = `
+Object {
+  "Mappings": Object {
+    "stagemapping": Object {
+      "CODE": Object {
+        "domainName": "prism.code.dev-gutools.co.uk",
+        "maxInstances": 2,
+        "minInstances": 1,
+      },
+      "PROD": Object {
+        "domainName": "prism.gutools.co.uk",
+        "maxInstances": 4,
+        "minInstances": 2,
+      },
+    },
+  },
+  "Outputs": Object {
+    "LoadBalancerPrismDnsName": Object {
+      "Description": "DNS entry for LoadBalancerPrism",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "LoadBalancerPrism310B782C",
+          "DNSName",
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "AMIPrism": Object {
+      "Description": "Amazon Machine Image ID for the app prism. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "InstanceTypePrism": Object {
+      "Default": "t3.small",
+      "Description": "EC2 Instance Type for the app prism",
+      "Type": "String",
+    },
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+    "VpcId": Object {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "prismPrivateSubnets": Object {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+  },
+  "Resources": Object {
+    "AutoScalingGroupPrismASG36691601": Object {
+      "Properties": Object {
+        "HealthCheckGracePeriod": 800,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "AutoScalingGroupPrismLaunchConfig969400AD",
+        },
+        "MaxSize": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "maxInstances",
+          ],
+        },
+        "MinSize": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "minInstances",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:pattern-name",
+            "PropagateAtLaunch": true,
+            "Value": "GuPlayApp",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "prism/AutoScalingGroupPrism",
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "TargetGroupARNs": Array [
+          Object {
+            "Ref": "TargetGroupPrismC8B388A7",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "prismPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoScalingGroupPrismInstanceProfile4740771B": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AutoScalingGroupPrismLaunchConfig969400AD": Object {
+      "DependsOn": Array [
+        "InstanceRolePrism96D154B7",
+      ],
+      "Properties": Object {
+        "BlockDeviceMappings": Array [
+          Object {
+            "DeviceName": "/dev/sda1",
+            "Ebs": Object {
+              "VolumeSize": 8,
+              "VolumeType": "gp2",
+            },
+          },
+        ],
+        "IamInstanceProfile": Object {
+          "Ref": "AutoScalingGroupPrismInstanceProfile4740771B",
+        },
+        "ImageId": Object {
+          "Ref": "AMIPrism",
+        },
+        "InstanceType": Object {
+          "Ref": "InstanceTypePrism",
+        },
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "GuHttpsEgressSecurityGroupPrism4A68FA56",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "#!/bin/bash
+mkdir -p $(dirname '/prism/prism.deb')
+aws s3 cp 's3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/prism/prism.deb' '/prism/prism.deb'
+dpkg -i /prism/prism.deb",
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "CertificatePrism0841D21D": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ConfigPolicyA2EB9456": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:GetRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/config-deploy",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ConfigPolicyA2EB9456",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrawlerPolicyB8C49604": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Array [
+                "arn:aws:iam::*:role/*Prism*",
+                "arn:aws:iam::*:role/*prism*",
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrawlerPolicyB8C49604",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DataPolicyCE0B28AE": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::prism-data/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DataPolicyCE0B28AE",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DescribeEC2BonusPolicy6E2176D6": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "EC2:Describe*",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DescribeEC2BonusPolicy6E2176D6",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyPrismBDF1EF88": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/deploy/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/prism/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyPrismBDF1EF88",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupPrism4A68FA56": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupPrismfromprismInternalIngressSecurityGroupPrism88D0F57890002962F735": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupPrism4A68FA56",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "InternalIngressSecurityGroupPrism75546EB8",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuHttpsEgressSecurityGroupPrismfromprismLoadBalancerPrismSecurityGroupE6A4FDFF900079618B08": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupPrism4A68FA56",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerPrismSecurityGroupB966F197",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRolePrism96D154B7": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "InternalIngressSecurityGroupPrism75546EB8": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow restricted ingress from CIDR ranges",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "10.0.0.0/8",
+            "Description": "Allow access on port 443 from 10.0.0.0/8",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "InternalIngressSecurityGroupPrismtoprismGuHttpsEgressSecurityGroupPrismF365BAA79000896502B0": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupPrism4A68FA56",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "InternalIngressSecurityGroupPrism75546EB8",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ListenerPrism140519A6": Object {
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "CertificatePrism0841D21D",
+            },
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "TargetGroupPrismC8B388A7",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancerPrism310B782C",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerPrism310B782C": Object {
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerPrismSecurityGroupB966F197",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "InternalIngressSecurityGroupPrism75546EB8",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "prismPrivateSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerPrismSecurityGroupB966F197": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB prismLoadBalancerPrismE7775557",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerPrismSecurityGrouptoprismGuHttpsEgressSecurityGroupPrismF365BAA79000A91E1244": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupPrism4A68FA56",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerPrismSecurityGroupB966F197",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ParameterStoreReadPrism8EED3EF6": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/deploy/prism",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SSMRunCommandPolicy244E1613": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-run-command-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupPrismC8B388A7": Object {
+      "Properties": Object {
+        "HealthCheckIntervalSeconds": 5,
+        "HealthCheckPath": "/management/healthcheck",
+        "HealthCheckTimeoutSeconds": 3,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 10,
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "WazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "prism",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/prism",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+  },
+}
+`;

--- a/cdk/lib/prism-ec2-app.test.ts
+++ b/cdk/lib/prism-ec2-app.test.ts
@@ -1,0 +1,12 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { App } from "@aws-cdk/core";
+import { PrismEc2App } from "./prism-ec2-app";
+
+describe("The PrismEc2App stack", () => {
+  it("matches the snapshot", () => {
+    const app = new App();
+    const stack = new PrismEc2App(app, "prism", { stack: "deploy" });
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+});

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -1,0 +1,80 @@
+import type { CfnAutoScalingGroup } from "@aws-cdk/aws-autoscaling";
+import { BlockDeviceVolume, EbsDeviceVolumeType } from "@aws-cdk/aws-autoscaling";
+import { Peer } from "@aws-cdk/aws-ec2";
+import type { App } from "@aws-cdk/core";
+import { Duration } from "@aws-cdk/core";
+import { AccessScope, GuPlayApp } from "@guardian/cdk";
+import type { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
+import type { GuStackProps } from "@guardian/cdk/lib/constructs/core/stack";
+import { GuStack } from "@guardian/cdk/lib/constructs/core/stack";
+import {
+  GuAllowPolicy,
+  GuAssumeRolePolicy,
+  GuDynamoDBReadPolicy,
+  GuGetS3ObjectsPolicy,
+} from "@guardian/cdk/lib/constructs/iam";
+
+export class PrismEc2App extends GuStack {
+  private static app: AppIdentity = {
+    app: "prism",
+  };
+
+  constructor(scope: App, id: string, props: GuStackProps) {
+    super(scope, id, props);
+
+    const pattern = new GuPlayApp(this, {
+      ...PrismEc2App.app,
+      userData: {
+        distributable: {
+          fileName: "prism.deb",
+          executionStatement: `dpkg -i /${PrismEc2App.app.app}/prism.deb`,
+        },
+      },
+      certificateProps: {
+        CODE: { domainName: "prism.code.dev-gutools.co.uk" },
+        PROD: { domainName: "prism.gutools.co.uk" },
+      },
+      monitoringConfiguration: { noMonitoring: true },
+      access: { scope: AccessScope.INTERNAL, cidrRanges: [Peer.ipv4("10.0.0.0/8")] },
+      roleConfiguration: {
+        additionalPolicies: [
+          new GuAllowPolicy(this, "DescribeEC2BonusPolicy", {
+            resources: ["*"],
+            actions: ["EC2:Describe*"],
+          }),
+          new GuDynamoDBReadPolicy(this, "ConfigPolicy", { tableName: "config-deploy" }),
+          new GuGetS3ObjectsPolicy(this, "DataPolicy", {
+            bucketName: "prism-data",
+          }),
+          new GuAssumeRolePolicy(this, "CrawlerPolicy", {
+            resources: ["arn:aws:iam::*:role/*Prism*", "arn:aws:iam::*:role/*prism*"],
+          }),
+        ],
+      },
+      scaling: {
+        CODE: { minimumInstances: 1 },
+        PROD: { minimumInstances: 2 },
+      },
+      blockDevices: [
+        {
+          deviceName: "/dev/sda1",
+          volume: BlockDeviceVolume.ebs(8, {
+            volumeType: EbsDeviceVolumeType.GP2,
+          }),
+        },
+      ],
+    });
+
+    // The pattern does not currently offer support for customising healthchecks via props
+    pattern.targetGroup.configureHealthCheck({
+      path: "/management/healthcheck",
+      unhealthyThresholdCount: 10,
+      interval: Duration.seconds(5),
+      timeout: Duration.seconds(3),
+    });
+
+    // Similarly the pattern does not offer support for extending the default ASG grace period via props
+    const cfnAsg = pattern.autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+    cfnAsg.healthCheckGracePeriod = 800;
+  }
+}


### PR DESCRIPTION
## What does this change?

This PR creates a new CloudFormation stack*, which defines Prism's infrastructure using our `cdk` pattern. This PR does not alter (or tear down) the current stack, as this must happen via a multi-stage process. At the end of the process, the most significant change to the underlying infrastructure will be our usage of an ALB instead of an ELB.

In this PR we are creating a new load balancer that will run in parallel to the current one. This will allow us to perform a zero-downtime migration via a three step dance:

1. Run two load balancers
1. Update the CNAME to point to the new load balancer
1. Remove the old load balancer

Riff-Raff will not be capable of deploying the stack created via this PR (it must be CloudFormed manually). A subsequent PR (https://github.com/guardian/prism/pull/244), which must be merged **after** the aforementioned DNS change, will remove the old version of the infrastructure and re-enable CFN deployments via Riff-Raff (more details on the migration strategy can be found below).

## How to test

I've deployed the generated template in `CODE` and confirmed that:

- Data is still being returned as expected for common URLs
- The new load balancer is reachable on VPN / not reachable when disconnected from VPN
- Instances in the new stack are still capable of logging to Central ELK

I didn't want to remove the current `CODE` stack until the suggested process has been peer-reviewed, so I simulated its removal by hacking the tags on original stack and ASG, which is sufficient to make Riff-Raff ignore them! This allowed me to confirm that the changes in https://github.com/guardian/prism/pull/244 are sufficient to allow:

- Riff-Raff to make CFN changes to the new stack 
- Riff-Raff to update the new ASG

## How can we measure success?

At the end of the migration process described above, Prism will be using our pattern (which is the recommended approach to using `@guardian/cdk`).

## Migration strategy for PROD

This migration path is not ideal**; deployments will be blocked during the migration. However, as Prism is rarely worked on outside of Developer Experience I think this is tolerable as long as we complete the process relatively quickly.

Here are the suggested steps:

1. Reduce TTL for DNS
    _* This allows us to roll back faster if something goes wrong_
1. Impose deployment restriction in Riff-Raff 
    _* This prevents accidental changes being made during the migration_
1. Merge this PR
1. Run `./scripts/ci` to generate the CloudFormation file
1. Manually create new CloudFormation stack with appropriate tags
1. Simulate a DNS change (by editing `/etc/hosts`) and confirm that the new version of the `PROD` infrastructure is functional
1. Update DNS and allow TTL to expire
1. Manually scale down old ASG and confirm that everything is still working as expected
    _* This allows us to recover more quickly than if we had deleted the whole stack_
1. ~~Remove Deletion Protection from the old load balancer~~ Edit: this is only required for ALBs and we're removing an ELB.
1. Manually remove the old CloudFormation stack via the AWS console
1. Reinstate original TTL
1. Update https://github.com/guardian/prism/pull/244 to point at the correct branch and merge it in
1. Remove deployment restriction in Riff-Raff
1. Manually deploy latest version of Prism, from `main` 
1. Ensure Riff-Raff deployment works correctly
1. Deploy a small infrastructure change and ensure that it works correctly

## Have we considered potential risks?

Yes, the migration process proposes is complex and involves many manual steps. I've tried to incorporate some safety measures to reduce risk (see _explanations in italics_ above).

*conveniently the current stacks are called `Prism-<STAGE>` and the more common convention in the account seems to be `prism-<STAGE>`, so I can fix that too!
**I spent a long time experimenting with different migration strategies, but was not able to get them working with Prism