### PR TITLE
Add an alarm to detect cycling instances

### DIFF
--- a/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
@@ -5,11 +5,13 @@ Object {
   "Mappings": Object {
     "stagemapping": Object {
       "CODE": Object {
+        "alarmActionsEnabled": false,
         "domainName": "prism.code.dev-gutools.co.uk",
         "maxInstances": 2,
         "minInstances": 1,
       },
       "PROD": Object {
+        "alarmActionsEnabled": true,
         "domainName": "prism.gutools.co.uk",
         "maxInstances": 4,
         "minInstances": 2,
@@ -913,6 +915,125 @@ dpkg -i /prism/prism.deb",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UnhealthyInstancesAlarmPrismC2D80E9B": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "prism's instances have failed healthchecks several times over the last hour.
+      This typically results in the AutoScaling Group cycling instances and can lead to problems with deployment,
+      scaling or handling traffic spikes.
+
+      Check prism's application logs or ssh onto an unhealthy instance in order to debug these problems.",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Unhealthy instances for prism in ",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 6,
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Fn::Select": Array [
+                      1,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ListenerPrism140519A6",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      2,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ListenerPrism140519A6",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      3,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ListenerPrism140519A6",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "TargetGroupPrismC8B388A7",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 12,
+        "MetricName": "UnHealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "WazuhSecurityGroup": Object {
       "Properties": Object {

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -34,7 +34,11 @@ export class PrismEc2App extends GuStack {
         CODE: { domainName: "prism.code.dev-gutools.co.uk" },
         PROD: { domainName: "prism.gutools.co.uk" },
       },
-      monitoringConfiguration: { noMonitoring: true },
+      monitoringConfiguration: {
+        snsTopicName: "devx-alerts",
+        http5xxAlarm: false,
+        unhealthyInstancesAlarm: true,
+      },
       access: { scope: AccessScope.INTERNAL, cidrRanges: [Peer.ipv4("10.0.0.0/8")] },
       roleConfiguration: {
         additionalPolicies: [


### PR DESCRIPTION
## What does this change?

Now that we are using the `GuPlayApp` pattern (https://github.com/guardian/prism/pull/245), we can easily add an alarm to detect cycling instances. This addresses one of the retro actions described [here](https://docs.google.com/document/d/11QMKU1J9C4aZR6cse_cE6vI1f_IKr0mLuALuwMpfJ3M/edit#heading=h.ofhrsl2zekxj). 

## How to test

I've deployed this to `CODE`. The alarm configuration itself was tested as part of https://github.com/guardian/cdk/pull/594.

## How can we measure success?

We will be notified if Prism instances are frequently becoming unhealthy.

## Have we considered potential risks?

We should keep an eye on this alarm and tune or remove it if it generates too much noise.