### PR TITLE
Reduce ASG healthcheck grace period

### DIFF
--- a/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
@@ -72,7 +72,7 @@ Object {
   "Resources": Object {
     "AutoScalingGroupPrismASG36691601": Object {
       "Properties": Object {
-        "HealthCheckGracePeriod": 800,
+        "HealthCheckGracePeriod": 500,
         "HealthCheckType": "ELB",
         "LaunchConfigurationName": Object {
           "Ref": "AutoScalingGroupPrismLaunchConfig969400AD",

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -79,6 +79,6 @@ export class PrismEc2App extends GuStack {
 
     // Similarly the pattern does not offer support for extending the default ASG grace period via props
     const cfnAsg = pattern.autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
-    cfnAsg.healthCheckGracePeriod = 800;
+    cfnAsg.healthCheckGracePeriod = 500;
   }
 }


### PR DESCRIPTION
## What does this change?

We extended the ASG healthcheck grace period in https://github.com/guardian/prism/pull/226 and https://github.com/guardian/prism/pull/227, as we believed this may help the healthchecks to pass. We have since reverted the feature (https://github.com/guardian/prism/pull/228) which was causing problems with the healthchecks. 

We ascertained that the problem was caused by API rate limiting (rather than increased startup time). Consequently, this PR reinstates the grace period that was in place before that experimentation began.
