### PR TITLE
chore: Bump `sbt-riffraff-artifact` to v1.1.17

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 // The Typesafe repository
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.16")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 


### PR DESCRIPTION
This brings improved branch name detection when using GitHub Actions for CI.

See https://github.com/guardian/sbt-riffraff-artifact/pull/64.
