### PR TITLE
chore: Bump `guardian/actions-assume-aws-role` to v1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-assume-aws-role@v1.0.0
+      - uses: guardian/actions-assume-aws-role@v1.0.2
         with:
           awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 


### PR DESCRIPTION
I messed up v1.0.1 😅 .

https://github.com/guardian/actions-assume-aws-role/releases