### PR TITLE
update prism to use @guardian/cdk 26.2.1

### DIFF
--- a/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
@@ -39,11 +39,6 @@ Object {
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "InstanceTypePrism": Object {
-      "Default": "t3.small",
-      "Description": "EC2 Instance Type for the app prism",
-      "Type": "String",
-    },
     "LoggingStreamName": Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
@@ -175,9 +170,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIPrism",
         },
-        "InstanceType": Object {
-          "Ref": "InstanceTypePrism",
-        },
+        "InstanceType": "t4g.medium",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
@@ -1061,10 +1054,6 @@ dpkg -i /prism/prism.deb",
           },
         ],
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "prism",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -1,6 +1,6 @@
 import type { CfnAutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import { BlockDeviceVolume, EbsDeviceVolumeType } from "@aws-cdk/aws-autoscaling";
-import { Peer } from "@aws-cdk/aws-ec2";
+import { InstanceClass, InstanceSize, InstanceType, Peer } from "@aws-cdk/aws-ec2";
 import type { App } from "@aws-cdk/core";
 import { Duration } from "@aws-cdk/core";
 import { AccessScope, GuPlayApp } from "@guardian/cdk";
@@ -24,6 +24,7 @@ export class PrismEc2App extends GuStack {
 
     const pattern = new GuPlayApp(this, {
       ...PrismEc2App.app,
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       userData: {
         distributable: {
           fileName: "prism.deb",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,11 +15,11 @@
     "generate": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.120.0",
+    "@aws-cdk/assert": "1.122.0",
     "@guardian/eslint-config-typescript": "^0.6.1",
     "@types/jest": "^27.0.1",
     "@types/node": "15.14.0",
-    "aws-cdk": "1.120.0",
+    "aws-cdk": "1.122.0",
     "eslint": "^7.32.0",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
@@ -28,8 +28,8 @@
     "typescript": "~4.4.2"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.120.0",
-    "@guardian/cdk": "24.0.0",
+    "@aws-cdk/core": "1.122.0",
+    "@guardian/cdk": "26.2.1",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2,724 +2,768 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.120.0.tgz#2de883d6719a5422c0c06c24037813c93e391864"
-  integrity sha512-XGWLuYZ06DXZpueiORN/HQvno5FDZXIT9PeB18xfbIv5v6BxVrbDDekvwKZmRwOqxf/cdhqdw68bw0dsmmIa0A==
+"@aws-cdk/assert@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.122.0.tgz#30a78c0784aff0ec57239a862c8d266f9f9ffd10"
+  integrity sha512-hgmN7Owmsk9F7rGsvD4LjhY7YukgMpKWNvbXHxsTSluoP2LF7MRwTcYu2bf/DAkYuY7tK1X8k0G4jeEZAie4ZQ==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/cloudformation-diff" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/assets@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.120.0.tgz#faf5f6483b32338e04c3c3a60fdb1d3f5b60a150"
-  integrity sha512-XbP4OYPx7Kj2YU/wTfRv/C0YM1rf296fZcmqk2Ld6MWKTrhslUNGw+rQbLhAEXIH+TQFgVLBy48EkqKhS6uQdA==
+"@aws-cdk/assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.122.0.tgz#58c1a34ce4ae59fdf33a9d4dc2f384c1850acae5"
+  integrity sha512-jNY/nXEWtoIONZnXfRr22i8PVp2JPDai4hofzu2/vnwZuJF+a+BlEI3yWzXaQMZ7ZNMnT0KSXwkaSque+1xr3g==
   dependencies:
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-apigateway@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.120.0.tgz#f4567dd43e14dfdb795233a3e94f7e38f2caf4e5"
-  integrity sha512-uSGltS2ozGQY9iuDyGOyZ8u+aKdGYn+kWSZ1JDCMHLgLj3p/yNR6EPC2eE5QhWHKLwuE8/eVARCBGoTtCEs3uQ==
+"@aws-cdk/aws-apigateway@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.122.0.tgz#5f2a1e3f5b7fedc951bbd4e25117d0954f4cfdfe"
+  integrity sha512-rJlocumxO+9uvEMrLc0iUxcq0jfn/+ckvJX76TsRr7ptXO8ydfEfwBcZjNtX0ypDOv6QShZH6KbqiZimgp/GbA==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-cognito" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-s3-assets" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-cognito" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-applicationautoscaling@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.120.0.tgz#258a0917b44874523d7d1fd6b8a3e55f50b17c8d"
-  integrity sha512-dBo36TfhTifpMcuQG4O4XI11lDZaoI+kDKLHjGx61i6Yed+xcOq4YHJAyB0VEiXdpIuMwfEyDlHzzFNqxnEuGA==
+"@aws-cdk/aws-applicationautoscaling@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.122.0.tgz#25330a0185cf9df77499677b528b260ca6db441d"
+  integrity sha512-iLXCGgQPfkL/bSIbtJXN5VlEqLyK/mnu+y8TtSsZ6ls0o3et1vHSZoVZvbtmlXdP/F+MF40rSwKqVrU1cMb70A==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-autoscaling-common" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-common@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.120.0.tgz#00fe829e9c8829575924bbbf80b2a54994b05216"
-  integrity sha512-9iuHMyNGrXnD8fjh/4ObgOM0GZ+BpM/a2L/RF0O3UrmXGQx6nnMHztySle80ngqELLQqdybB9flrApO8mrUVpA==
+"@aws-cdk/aws-autoscaling-common@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.122.0.tgz#fb001f5b85b927063dc5dd4c28c4534127cae251"
+  integrity sha512-vTkBJGOHKr16S+4XOhkqvHfzapSKVJ+eHe599B2imhC5n3hui/ly6jc0aUGXT8r2yIUqGYuqVJLVW0OlHZRjBQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-hooktargets@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.120.0.tgz#8eff32d8d01c53751f866ed48ab82bc49f53d7bd"
-  integrity sha512-o/lF9k66gpEDhvV1vBS4qjM5HJW8rQdyIiGIkoWfCnkJT3Ad6sxVPz9NQFXNiQgahPO0xbK7V5hLLRSEzdGCnw==
+"@aws-cdk/aws-autoscaling-hooktargets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.122.0.tgz#33e2615b75a013d3d2f043bb7211aef8d1dffac1"
+  integrity sha512-4oDw8zveuEMUmOYZQ96cAVVw8o9tM1BEN1Jb+Yul+GVw2xJPzHMxbDn3IKvIqu+dL/9dabK0fq5Tpve74RHb1A==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.120.0.tgz#c7bec8ac8b3a43dc24d94dd1c4cf404741f58d08"
-  integrity sha512-NmivBFnOtaLpzFOnJ17Tva6oCFyuz+ssN0whLYNAgkyWQAAaT1/UqLp/+jiAovmASjtP40CvKGet2SpPJ7R69g==
+"@aws-cdk/aws-autoscaling@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.122.0.tgz#d4c8f5b02306c3371279ab601dbd6b2ad7b8d4ae"
+  integrity sha512-K/DNeCMxRNhtksOW6JIVDcng8FSnGQHV6ScTnYTUeJGOJpNgwF/pB+nW3Bmw4w/QNyt5lN9DnHs6NIYZjTDMCw==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-autoscaling-common" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-certificatemanager@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.120.0.tgz#e7a5889f88de79c5883ba9dbb07d2ea7cc4a6e3b"
-  integrity sha512-tMAN4pw/cRdaZ/KLQZLb1g4btI7WQTMEMGW9jEPzJ8LoaRPRygFQnvWDSjb5iOsFBeT3D6vI4dzZr5r2jO69RQ==
+"@aws-cdk/aws-certificatemanager@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.122.0.tgz#f2eec2a41a48998667e5d5578047a4f1d9e60e9e"
+  integrity sha512-ULrOt7JJWBisQz9ImjXQT/lSvOHobNqBGLP8nXTltlIktPO1oqdtcqJGYq0+XXXRz99xmw6O9K5raDpAc/eKIQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-route53" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudformation@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.120.0.tgz#612223e65564d41498d86f7ae3e30ea45aeea8e6"
-  integrity sha512-Mdgh5Lo0JH+wHnjQCfU0a+sATAuLUbOMpnyqRmsNb1KGoPuW1lgAqBwS1oF6ciFTvnrjq+fogX2kEPmYvg92Fg==
+"@aws-cdk/aws-cloudformation@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.122.0.tgz#b077151c001571188688678c86e3053ae64b52a1"
+  integrity sha512-ohI6cKwqd7YuibyvBGn9I0V8hf0MU1uHQvNRBy3teMMXOVwUrJbGKeeA5uBppAlJFmGanUpgiScEOJW9FvKW7Q==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudfront@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.120.0.tgz#7685a0811a7085ee5c56913655c1d158bc7fb6a3"
-  integrity sha512-IYQ4oDYlRDX+obl6Kv2Q3Jn22cm0tRQDE0oHtbHdiTUa7dx60tWBHS+m4wse8j3mmSkOKOsr9sXnhEtD3+zMIg==
+"@aws-cdk/aws-cloudfront@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.122.0.tgz#2e8ce364e725d24652a2d200bfb6c28c131810a9"
+  integrity sha512-JpX2ad/EEGLUuW9guOxDChBdIzWHFG/tx6XKBO0XKgoZ/4Yqvz8CLtA0lSet5hLbly11TmKHZcCm/FoqjUj1Jw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-ssm" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch-actions@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.120.0.tgz#8665243e0aa9c6561467aa4bc0a335cfd387eb72"
-  integrity sha512-CI2cAYCt59zzmB9iLFUXBN7G3dd+Kysb6UyyFDx3bhIUD48+Vqn4t8369zKzBW1Oo16e68EVEXVN12vHRO/hHA==
+"@aws-cdk/aws-cloudwatch-actions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.122.0.tgz#dc9a53dd8fae83bc4f88143a9ddc238da3712526"
+  integrity sha512-QDipB9lZY2P9rnn51oaIriVASdfIF3Ymh5JizpThthFxDubCtkJul0jUbbp3ZM6kQ4ILS9X7tlAD7waNvmh5hQ==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.120.0"
-    "@aws-cdk/aws-autoscaling" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.120.0.tgz#b2225959ed6dd876952e27c267798e43df462d05"
-  integrity sha512-zGKQ0FRhRdnWuyxjW9cAD4U+PfIc9ylxyP0ipteVmOChHs+HvltImY074STLeH7gGkJUfIo/7TqYG7UKcfTBnQ==
+"@aws-cdk/aws-cloudwatch@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.122.0.tgz#25724ce559e423f498247b8821fa1564a0f94edb"
+  integrity sha512-K7kFyc5MlWTBTxQrNg32DZWGJoYXTKxjc/5i5HJBPYPNOeG+joK+3fFiG9seBmea4O3xYMHg7vbuZxcvM7AbSA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codebuild@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.120.0.tgz#64951f2f45aefbb8ce639a5ead963af2a48b00b2"
-  integrity sha512-Mrk7jgtI3QiN85zF4XMKZvuc2kO8qdhNAsNDsYijKm39ymbfHa7mnDYzpYvOtx9nn2IbSG5ndUYjdK+OpLPfpw==
+"@aws-cdk/aws-codebuild@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.122.0.tgz#5f8fabb9fc3ecb0359b5c26f6254b3bbb821338c"
+  integrity sha512-Wa73Y02E7LNCHAm76KnJJEikC8HuX8symoVlR9YhZnqFhG3CbynpCgzlNZIhObiUaU2u5L9r8WT3hyYK/QfN8Q==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-codecommit" "1.120.0"
-    "@aws-cdk/aws-codestarnotifications" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-ecr" "1.120.0"
-    "@aws-cdk/aws-ecr-assets" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-s3-assets" "1.120.0"
-    "@aws-cdk/aws-secretsmanager" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codecommit" "1.122.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
     yaml "1.10.2"
 
-"@aws-cdk/aws-codecommit@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.120.0.tgz#c3fb9054847386c9148e5e84eded85c13f915dc1"
-  integrity sha512-C/wS72ZE45ePYW1GpP8Qv2BHK0aipIK2t2Aqr62gly8IvueWlfsqv7eqykGa4gw2vIJV9gHZvCUZOaKDTOqBdg==
+"@aws-cdk/aws-codecommit@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.122.0.tgz#60da47c1465eec26d209b8ef908712c9f0b56ed1"
+  integrity sha512-vAMNkNZ5YRI/kgAX+sm3g7E0yLWHAhCFLHnTdBPTtefDxwYudP/csdKBiVOHWh+beB4pJugVLn7jPxwyB2Jc5Q==
   dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codeguruprofiler@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.120.0.tgz#93378be9871058890dd4bfdd57e1c6ea72e37496"
-  integrity sha512-cJ6VAJt3HWkgp/3t/1YsjJxo3yLpVrhAelwrEFlvQkfKKyTCD/i+L2eL4MaD2lLPyCCxwK7LKvnr3BgclgKtsg==
+"@aws-cdk/aws-codeguruprofiler@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.122.0.tgz#59770d5c7dfffb8abd156a75cef2df8a3f1a6fda"
+  integrity sha512-gwMtyzr2EjvmOuzIPSM2ooUscmGZnhh/B2Zvjrl28/4UAH6EM2kOGdnZtbzFOzUqT5XqsttVfKycPFNYQscmJQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codepipeline@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.120.0.tgz#28ac286d77f04bafdd7e920d1861c0cd77fc5a0c"
-  integrity sha512-oGyHDuEY+k+IXyzQMmcyWm9d8fZ9RkvQleITyvn6KsNSOVwsrW2O3it70Z7k6TVHHCHK5O7XvNIEzV+IMdx4fA==
+"@aws-cdk/aws-codepipeline@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.122.0.tgz#49c08fe31c2b0fb36c0c62c09b32641ecac792c1"
+  integrity sha512-oLF58W3e3e32DICIFg+d+Qf5bM1wXA8TXYtNdUVDXKPCgt7Lyd+aqxlYATFrCSAhjrdjoy2Vj21x9WF8tLRzZA==
   dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codestarnotifications@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.120.0.tgz#7732a5232041e7be18e15e2e18f2aa1370d04737"
-  integrity sha512-dqbl0vIe2muXzhhoy6lCYKyPl4KNx+N5BQ5avLWj+Rd4NysEKUaAQEGsEX243R9uo0ZJyA4Jo2RYXN+m2b5G2Q==
+"@aws-cdk/aws-codestarnotifications@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.122.0.tgz#92049ba8eb6a54a61210506ae6dd0f3af6a83be7"
+  integrity sha512-STdYT94spdxtaODanwW5M0W6V9kaJ9szpPQubYXTKnpKxZ6UCKANKMj+Fqp/zJxlXQqnuaHuMtol0nA/Xt2bfg==
   dependencies:
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cognito@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.120.0.tgz#f81c25b070eac69fc9d49c5c3df0baf3bd211e77"
-  integrity sha512-EFFiJuJhRGkVjB4LGWIth5DKnKPL1R2ZLbKsYtTcwnc3UZIbKtHZS6STQd8wYvM0rryagukmS+rdC9l+NmGWJQ==
+"@aws-cdk/aws-cognito@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.122.0.tgz#a18d1274cbb0d240e365c7edc23b8c1fad1ecf13"
+  integrity sha512-eFdW890ZLaN5c7qQ0/RqQB2Ufta3aQC5tnJzGdkEb9JQfoM/fSL0s+jmpriUHUaD0wok9la34gPq7iKq55B29g==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/custom-resources" "1.120.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
     punycode "^2.1.1"
 
-"@aws-cdk/aws-dynamodb@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.120.0.tgz#42a87335d2ee96c35ef076f945b16d8de96acb40"
-  integrity sha512-u6mV15vpWSWwVQZIeY6cJwc+LK3yT4szIeo7rTHFp0+QrGDEUZsFffnn89XszsdNbbDnyam9u3mKuCYoEHlFJg==
+"@aws-cdk/aws-dynamodb@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.122.0.tgz#d2402d1cae815910c6a89682dc4ae8978779eec7"
+  integrity sha512-zsEMFxKMxVoa3vyOP4zWD09rXaGKXbAHXhtjhY8MeupDE42ZrspZLybMHycElCVwq8JQjcq0G0oBzOodR6NnPw==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kinesis" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/custom-resources" "1.120.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ec2@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.120.0.tgz#a8898561556eca5e739740fde8f053560f07eea6"
-  integrity sha512-KF47sR3dHeCWkK5Ch6r6Kdf0ZFn8Hme+SgCrv/5PvftYmlJrOLFWb8QNn46Tkd/BZm0IZumCHK4SPDmMSfyXPg==
+"@aws-cdk/aws-ec2@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.122.0.tgz#31b2280629404a829eb639e8e373221613a1aded"
+  integrity sha512-bKJGgd3KruFeOyP/5Fc/Ufr4BHB9+xVpXVGqCeKEInkq0f4ttWhHbfKRJdYEUBEF0xwDQEj7RM6EgaV0fdfb9g==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-s3-assets" "1.120.0"
-    "@aws-cdk/aws-ssm" "1.120.0"
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecr-assets@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.120.0.tgz#9dfa0893aecbc1a5bb75f5215e66e1e27ce044db"
-  integrity sha512-LLFM7aAl5QuRb1WqAvAuuVreduLL0uQk8rr9J5gbZSc1Jjjs9TNLVKdtvS7K8VUaZ9unVNvAARm/MXuqOmETeg==
+"@aws-cdk/aws-ecr-assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.122.0.tgz#6483e869202c272f83e37b7c5003a5b1d4d14813"
+  integrity sha512-BFYCNsUs/1Dlh41bXmFmq41RpNatqm/KHfIWA0eFNIAuG/IqOga9LF71zCBiqv4gfNmfGQg19Sq2BojGQwisVA==
   dependencies:
-    "@aws-cdk/assets" "1.120.0"
-    "@aws-cdk/aws-ecr" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/assets" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-ecr@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.120.0.tgz#ef9b5f74a6f1d5f34e094c5021ed3533a62c2c9c"
-  integrity sha512-YiF3h4DPxIzV/7muHA9iLgyNSJgPSPhcvcOpW+eatFJbp7LyfIb/m0By9NwxKx1MixSZM4DU+kQbpRxUDXlk3Q==
+"@aws-cdk/aws-ecr@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.122.0.tgz#a86a52e32d74cd48dc96f7b7613b7151213ea8e6"
+  integrity sha512-FxM7Q/6VHquOdfWrKQArzs/91fxvZFwT/FkPIrEm+X10/voOFI6S6xRXaOlr2UVn6dji6J6DssY7YBvJq1ciOQ==
   dependencies:
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecs@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.120.0.tgz#d7741fea576d7fd1452f66ef2caa21ffd6498db9"
-  integrity sha512-0C5tbRDs9XKCwo2/PpoW1pePz2xjwuTsMpjnPt3RsDSbPButYCpT9id8ANCODycGvdTknhMu/TT49bOS/7G1Yw==
+"@aws-cdk/aws-ecs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.122.0.tgz#6d7e4c34a4e28881bb94e9f43762653c9fbff208"
+  integrity sha512-SdgRi3TsAOGigVga1HRiTsMlbkC5nosmQJ1P67rF2IcXdhoToKLFrXSLskFsO50JjmK6781efhW6xZYvvTlQ/A==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.120.0"
-    "@aws-cdk/aws-autoscaling" "1.120.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.120.0"
-    "@aws-cdk/aws-certificatemanager" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-ecr" "1.120.0"
-    "@aws-cdk/aws-ecr-assets" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-route53" "1.120.0"
-    "@aws-cdk/aws-route53-targets" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-s3-assets" "1.120.0"
-    "@aws-cdk/aws-secretsmanager" "1.120.0"
-    "@aws-cdk/aws-servicediscovery" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/aws-ssm" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling-hooktargets" "1.122.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/aws-route53-targets" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/aws-servicediscovery" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-efs@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.120.0.tgz#1a7ab377575e25f3a43a27cab08fd5aa1ecca2d7"
-  integrity sha512-Q1fzHKIP1SS6EFhESM2BPmZ1h0U6hzD9K5z7iMPfmjMRPQeOzXS8VPQdSJuzi++M7+2B5eAITkEI867nmutfkQ==
+"@aws-cdk/aws-efs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.122.0.tgz#b0fba574ccc35f4c6989828f2234c88b8e8e6566"
+  integrity sha512-CFvqAVv2BX31j+tGxM2a8CaTbf2QqMoeegORRJzipykeX+wCPu/5nYA7jWOXlCLYZ2MnLRHaAZzzVtLRvgNSWw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancing@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.120.0.tgz#df925d82bb87376dfb3225ff2f1b071d913a2cf8"
-  integrity sha512-arUq1hGx67z9LkI3Q+MIBb5fIFYA60DatdiGtyYFg0YoJtj6fmHgByfowtJLrpv3iDq/UaIn8k392uWL59Be3w==
+"@aws-cdk/aws-eks@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-eks/-/aws-eks-1.122.0.tgz#25113b3d6ad4804224cf95310f1bb5b1a082501c"
+  integrity sha512-/T876MGxQD6D9o4C6wlHoZjqYxnxU0Iw7O1fKzp4tW0A+F3ykLwls9QcYDxZlIfSEFzLhNKSKFBp8Lrfx0hHxQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
+    "@aws-cdk/lambda-layer-awscli" "1.122.0"
+    "@aws-cdk/lambda-layer-kubectl" "1.122.0"
+    constructs "^3.3.69"
+    yaml "1.10.2"
+
+"@aws-cdk/aws-elasticloadbalancing@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.122.0.tgz#b96ca26fae657fe1ad3d4fc86bdabe17b11176f7"
+  integrity sha512-LdGcPIp60QLP0SGfgQlJ4N05NT7SCjwzZ3n194+bKlEs/SZ/3KdyCMg4yGKbg9MxcvOV3ADBO7JEy1oEc/b8Sg==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancingv2@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.120.0.tgz#87be577ca45d585745fba964216fa925774d9039"
-  integrity sha512-x4x/9HqOBXlqLmtmKxRGKsgQ1lW3DVJMet8ONahEPsL1zLb2nRiQooJ1b95U6QmIJ6GK88VC+v4TCuiGBBYl0w==
+"@aws-cdk/aws-elasticloadbalancingv2@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.122.0.tgz#3fa95a24c303c44ebc7bb2c15a3289f6197a8c53"
+  integrity sha512-WilvbbVtulDBI1QV2uqd7vlCUKvjjDR6t+WvbaB6iNHyGLcuRF8Gs7aOiIkTbZorkzL68GrKlXmu/oj9dolVHw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events-targets@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.120.0.tgz#fc5e80c348a5be46fb4ed070deab544171b6c617"
-  integrity sha512-cCRNc7420D394Fb3k4xowQ8UA2oz/HIHoSDzGm26A0R8Wbgha77sHccYn8Romxj4oz/+GdC1rkptyJ2vqnVwXA==
+"@aws-cdk/aws-events-targets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.122.0.tgz#7757e1e97b94e4c0274fa8b209555efeda823851"
+  integrity sha512-tgBZBQWzt2ePhoVjbpRHnAmCnpJEgjuEn6bAyjpGT6ucjzuL+l3gJDDbth2c3B74eJQB9N5FQ+RXq3coTaqiew==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.120.0"
-    "@aws-cdk/aws-codebuild" "1.120.0"
-    "@aws-cdk/aws-codepipeline" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-ecs" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kinesis" "1.120.0"
-    "@aws-cdk/aws-kinesisfirehose" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/aws-stepfunctions" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/custom-resources" "1.120.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-codebuild" "1.122.0"
+    "@aws-cdk/aws-codepipeline" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kinesisfirehose" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.120.0.tgz#fe65715033f0d29b019b6c9a0c9ba3ef7297745a"
-  integrity sha512-LEPMi9lPO7ywXxrL2Cu2tSr6aivDHYWWNtbNOto4BXWAwy5+BEL4fRujx25XAf0G3b6DJtatGXOM8E9Vnyqk/A==
+"@aws-cdk/aws-events@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.122.0.tgz#c128fc8b9fd65e82128dcf095b3f25a250c62b8a"
+  integrity sha512-Nc6flYv4Z0P6yK0rIhuUnjsOVEucgv0WdV7va3WzPzp8B253ea0XdLfpSJxGArKAH6qcmCJmd07ls+N2omzFBg==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-globalaccelerator@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.120.0.tgz#168e64319a06d1dd3435148b7f565c472daf4937"
-  integrity sha512-aknUNWg1CNJgNczIe50nlv2F5AY1D0icZhBAJUhFLKgdXDuG21D3UW3H+8uQ4xlvsb3dSNjp9giYUoyqKK4Fjw==
+"@aws-cdk/aws-globalaccelerator@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.122.0.tgz#42da4ba7998919be7b681a4c36f2c44d9482b4c4"
+  integrity sha512-9fwf7nR91bKce7u0aIS7OdVVJ52KC98OfhVO7cTTGS8YHjEnHZIpmNvNWgA3KMinpsMuqiIRIWJrhj2GREis6g==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/custom-resources" "1.120.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-iam@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.120.0.tgz#b7f8db5a7daec0e1343a5f0cc601fb6698ce59f9"
-  integrity sha512-AeZ0z90YONwb/NWPW+xbKnb7eH0olKzI8f5Z7DL0Wex3KpMA7DoRfwdOXs06vQsz4JEJYM1BwzhG3llOMdoJxQ==
+"@aws-cdk/aws-iam@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.122.0.tgz#6e9bae183c20e554f9044dbadc1815bc4e01510d"
+  integrity sha512-IGPA+m45NFZijzRgXpKeKemt2+8Yba7Se1ru1/h7t2obhpdw/tcsTLhkBVagWGjSyw7zfVDIEJZTe5y5lxyQbw==
   dependencies:
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesis@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.120.0.tgz#849a5a2da7d5cb545a7dfd72debd779f25860695"
-  integrity sha512-8CxsDscOWAryRz5pkDyx+Pk3wS7J5OUG5q/ych7XE+s6EU6URQOzB4m89JRM18Xj+9JNP8ifc1mnlERPwb2w9A==
+"@aws-cdk/aws-kinesis@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.122.0.tgz#611fd4fe5b9b62095376f5ee31ea25222fbe7f56"
+  integrity sha512-Jfjcon4IOKJOoFJ1W6aqmc/mDmSWWPx0pB6CIW4nPY4/bHEYvyVnxexTiZW0aG3ucdaur6atDc+DVqo2quyVAg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesisfirehose@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.120.0.tgz#ffe7ca06dfb1cefcaf83c131b90342804ef7955f"
-  integrity sha512-0KPXchFX6Cm/N64SizYSvj8FjfWI+QnZ4QsdUPZOwLHsiHdSJS/kgDGqq1ZZYij1KGKcOSYOXZRaO3lGX7qujg==
+"@aws-cdk/aws-kinesisfirehose@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.122.0.tgz#0aa9954d153e99679c70a6f4b63d8da34dc0b72a"
+  integrity sha512-n7++SIJe0Xpc33gEBrUuxNj5EK0vzhEvELmdTYA6s1gEqjcslEZQzliziwCtlzwsz7G91JCMTrjdc8/0yzofKA==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kinesis" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kms@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.120.0.tgz#16e8f69b72d65afa357a3a14504a846756f4edb0"
-  integrity sha512-n57Gt46BxtrBkPikAwbo+S6aIHstPUAVL2J7cJZ/ZiU91HMOkranMCOnYa9IQ4k8coZQAisSMfp6PEJayd9i0A==
+"@aws-cdk/aws-kms@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.122.0.tgz#0c9710a2ea4828725a4a7fac802a130c8cd9333e"
+  integrity sha512-oVaHgb5L4MXVt/mb1HpDr1dgVuyBNjbVe2To8WOuY1Iah6on7dh725479IObSw72lLS/5STo8XOAGKZ9h0aobA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda-event-sources@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.120.0.tgz#4112ceaedc6f3791ce6aef4fa6bd69d3b2a46094"
-  integrity sha512-cyJfQ95CfLV289FzULjRVeXCLNNVOKt4sLqTdZNfsbM+Ytb2I0L0Uk9P+e+/7ca26Mu1tkttUGx01uiYqRL/Sw==
+"@aws-cdk/aws-lambda-event-sources@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.122.0.tgz#f472c5dbb22c1be074d8f72d1b7aa4a93a3b7c82"
+  integrity sha512-1ftiIwds4AVUjkrCGgkNWqXtL4CDtWaQO7zRdQMZ/7uX25ZjtospJUiPIK6ZILCX/mSYTJtUEQqnMsbuTvqPRg==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.120.0"
-    "@aws-cdk/aws-dynamodb" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kinesis" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-s3-notifications" "1.120.0"
-    "@aws-cdk/aws-secretsmanager" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-dynamodb" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-notifications" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.120.0.tgz#9551dbd91182ee8c1407ed769f91df9b512c7200"
-  integrity sha512-eQuw91z1vBf6xO7Zkzym/8eOqPIKaBTZ5w82oR54rtFB2V6JTk6PdQkYIRFaumR/lptD2O1rAS0Qml2gccB8Zw==
+"@aws-cdk/aws-lambda@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.122.0.tgz#1a870272770f0454235bf394c063c556bbc13c4a"
+  integrity sha512-tAJqGEfyrdVebq99V5vCYg8y/6lhcRlhIbSPRn4h3tKzkSfOhiXqRZD+0qfBA1nF6l64oWI5K+Y2N3DyQEemXg==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.120.0"
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-ecr" "1.120.0"
-    "@aws-cdk/aws-ecr-assets" "1.120.0"
-    "@aws-cdk/aws-efs" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-s3-assets" "1.120.0"
-    "@aws-cdk/aws-signer" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codeguruprofiler" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-efs" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-signer" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-logs@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.120.0.tgz#857d40850eafa3583f49790c0c1fc66af882a140"
-  integrity sha512-kUiPmEt4CIq9TsAW0wdwna8os8BQrdCoqqO9J26PpsB5rL/MNlVCYpf6rDBwujEWD/p+8tPgVwWVsz6j73RXyw==
+"@aws-cdk/aws-logs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.122.0.tgz#aefa41273f309dd0bad91e3541390164e91fd35a"
+  integrity sha512-AKoqNClzvkjcFQYJoYZ9VpjmQfqVtGIJ9pTrOlfWQJV+MI7H2wyK5hiX5gOWDOyd1fqXtGTdrI/fvfIbDo2UQQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-s3-assets" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-rds@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.120.0.tgz#2c5187ab021b3e642a3c7cfebc2b9135e760a0e8"
-  integrity sha512-+CxPlf1icMC2rGDcL2sKu1/YGW6oZEyI+sfFo7SUXo9CKIUfMml4dm5Z17u8nrsE+bgR8GkE2GWPOe9E5o9zZw==
+"@aws-cdk/aws-rds@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.122.0.tgz#a312d74703b9b6079b602a37af079bfa2eed95fe"
+  integrity sha512-Hdx5BFpRTLljT1afI6rFF6XojDpsOT7Gm/e6MrErGxQyxZ4tgJMBTLpHbbmB8cee2fbVXt1zM35XZxY+EXfPTg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-secretsmanager" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53-targets@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.120.0.tgz#7e407091b95d1c5e8f0f22f53d14741f59f8cd2b"
-  integrity sha512-o8QcnLlRzII/eAXp9/G3FzAMZBZs5BVJX2CvcYpz32uGw4FVINb8r8nF4pVWK8uLOQdznqzIa3mqZaFuckQAZA==
+"@aws-cdk/aws-route53-targets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.122.0.tgz#120128df6344688c692980a967566f03e84e167b"
+  integrity sha512-ZJZ2ogVr1434mSHkNJ9RdN6twMccjziqPr8IsacImJ2WnhYSddzLanvD8dZXJg/Yu4r/Jx6h5Tj0kQcEEG9XPw==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.120.0"
-    "@aws-cdk/aws-cloudfront" "1.120.0"
-    "@aws-cdk/aws-cognito" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.120.0"
-    "@aws-cdk/aws-globalaccelerator" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-route53" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-cloudfront" "1.122.0"
+    "@aws-cdk/aws-cognito" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-globalaccelerator" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.120.0.tgz#c551a644e421997fdbcfd0ecf0fd0e7627db18c2"
-  integrity sha512-i6zrLICYCZZ9Ym55kDgVeTuFBBj1b0gl4xtqsamJdA+rs1rf9tyfqhq0Y5/rWd4u3mgMMFAcgO+PWcMJPkQJHw==
+"@aws-cdk/aws-route53@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.122.0.tgz#388086a679943a95c06210f1d480c08e0e85d2a3"
+  integrity sha512-rGuohz5NyujKGS2pnS78DsFS7ucvcvlzKVnah62LHYdZq9MO6ZfHpa79d1zWaeyOOS3ELD2nopAeLIfE84pEUQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/custom-resources" "1.120.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-assets@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.120.0.tgz#3c25eba70bf5c742bd9bdd7a4355e5e29c3ad5d3"
-  integrity sha512-+bZskdp/MpbV7A67S4HTVwgFZy6oktgUyMY18iX3gUos3iMfVlg+1jeFwvzzsfxmv37n/z0Y13lfJ3LKMjV3ZA==
+"@aws-cdk/aws-s3-assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.122.0.tgz#3e53fa99855932c52ba7a8b11d028579c80e9221"
+  integrity sha512-+Zqt3lK4fXoAUmGFGI5dKGe3ErwOIBrZlejTsXcO7DbrBYXGu2Wxpk3yMgsDkkSyP2uXyEnhxSqCahZOS2vRZQ==
   dependencies:
-    "@aws-cdk/assets" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/assets" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-notifications@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.120.0.tgz#4e884e8eb466a96df4018ab4cf88226b9e757d08"
-  integrity sha512-0BBrtk8WkPm8Z8Ix3f6GZKPTKT+WASY1R1w92Pd2G5UgstpnFKTjzTRctJr+Ct3QNC7hpGSumO7fBwx9WT+JCA==
+"@aws-cdk/aws-s3-notifications@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.122.0.tgz#83d5eed49a698e18c5b39533199c2d7ab120ea7a"
+  integrity sha512-euq1ZEr9h+zdGbVN0yQHUPgmV+7Y1Qc0RdmMcIbFQafEFTmvvh1A6EnQb/SqPeNVYRwgv0iNj/7JRsnWbBdvuw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.120.0.tgz#b555a832622e7f8d08beba43c39ff1c2a6938fa6"
-  integrity sha512-arMKYYhXV05JMjytMYpXFyF/2FTjIMcVyjZmSxTvISBzB0GgxGoCHjB/g1oj1w2L3hpV9/lpY8ZqQPuFM5PclA==
+"@aws-cdk/aws-s3@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.122.0.tgz#d4432c320559aaa8756c4dacc1d7a517c7121af7"
+  integrity sha512-QveBi5KrUusyEc9Ap3998Gs6gUq5H5FQeYAHX+bDIsYgwOWajVStYpzefPfjnAR5TuH8+hXWVFaDzY7BaID4Uw==
   dependencies:
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sam@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.120.0.tgz#caac114f7215183f1ed280b5bdf4c088a706289b"
-  integrity sha512-ZBkC7xIR6uvGcPqpnGKt7WALM2EnzshfBWVMdndlGU3oPYqMKfcSAj0VuVR0B81pz+nm1eYnRMECaYsiCtjx3g==
+"@aws-cdk/aws-sam@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.122.0.tgz#9c0d79572fad71c1ebcad6c34031247630888c67"
+  integrity sha512-POuc49ctbNHMnbEdA7vR2h2e+tWasmmYtl2vBYlGqMRNXsBm+o6LvE9+x7/kAcJArGbVB9U42FebcdQN8kAdew==
   dependencies:
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-secretsmanager@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.120.0.tgz#c781bc2d06727169704dd5ced3c90da7c8f17736"
-  integrity sha512-wvePcTpKSj9OebhxMCwLURjgaQgZ4BpeVTjSQ68yqhO+vtB3uUPkn/SjAU/n3A6CozyIQVGgbbd/cGYqPFGInQ==
+"@aws-cdk/aws-secretsmanager@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.122.0.tgz#077a43422811af6800ff3a5d10ece472b6f32493"
+  integrity sha512-wsmsD4z+SSrljj0u3Nk9/xLzcRusCTxGO4JrlC4gTn5YwIhSqDbsxOauSLRHnM+/tOE6C+t5vOfFd3ZrV2YH9Q==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-sam" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-servicediscovery@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.120.0.tgz#f2e61eab2750974a22d1dd07ff97295bce348f24"
-  integrity sha512-zsWrs6/4TWGW5K910XbZfiXAwZfs3WUIbTQeIR3q138A3ypPpl4X5V+spOAOIWVurim8hBpCswOG/+awUd72aw==
+"@aws-cdk/aws-servicediscovery@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.122.0.tgz#267f95f7c874c6ea9cb8093889c0c1eb20d75ab1"
+  integrity sha512-YjdlJS4tEOqdh0h6RpJl065WZZvL0rj1Qp/pDK32bS4SFmpk5YFFwpcIX84zbJXodn9Hhbowyd3Wzm5ZQMr2MQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.120.0"
-    "@aws-cdk/aws-route53" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-signer@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.120.0.tgz#e610a42f92ac6c787bb018fddf1a27e9358c2c03"
-  integrity sha512-kRq5tHbnF8QiyjFWHo2QVCeAX/WyWTldp14piqOh6/UdzXYC8mRSFPw/R9+p7fkdAeVVcaQcSXFCkI7i8dQYlg==
+"@aws-cdk/aws-signer@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.122.0.tgz#9a2b6611407f72ca5101bc2ee0294b8b076da418"
+  integrity sha512-6J59KrTKtOyH1i3MxQ/9zIfYIocUgGZdqyq9cV7srZ6yUSQp1s3xR+b7LWbBUxs3UMMLXTwchhX/Birc5mXsUg==
   dependencies:
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns-subscriptions@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.120.0.tgz#be1a0102dece172bd12ff316745e7a9fdd353577"
-  integrity sha512-UOxtTyU72Pw8KThxpw3YqDzEgh2vHn3JMF9tqVWzAvhJuKOpcVGZqxJdPme5I5pUYEtLAPS0qTTbzsv9FDByJg==
+"@aws-cdk/aws-sns-subscriptions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.122.0.tgz#73a21c71c51b1f85f9846ee7557b03f2d0cdaa88"
+  integrity sha512-kWshuZLSrniXkROAv9TzA3SyTv/hR0Z5uTRIBuHcG5tkR0OaAFomGW3DUfddAI8a4N7rq6u15cSOWPzLVK4EcQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.120.0.tgz#4f7c28c23503786c5da778b8be6a197f965ecad5"
-  integrity sha512-kLW+BwdbFc0wlF19R3ngyEE5L+C73ghDOYCk3S4/6WvWvhuY6KnTjSyaEJ4TikkrXHwWLGbYGo19bQDtRQj1mw==
+"@aws-cdk/aws-sns@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.122.0.tgz#66e15ff3b6ad1866a858109d5c844c122e45fc1e"
+  integrity sha512-nAB4eMJI4tHBsLjsLdPmwhkZkl1M8t9JFv6L1VdH6Y0yxz8V4fVOkPf2btovmVQ/oyniHX+DPkJzmyGw8lnsjQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-codestarnotifications" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/aws-sqs" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sqs@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.120.0.tgz#ee8022d2ac5068f06747c0d4780af86e16c757fe"
-  integrity sha512-YgLSKJ5QnzDtwl4lDdO9XphVIp7IXZv4GPs9h4gC5jJExaEmTx17yTAMrGZ7b4xqS6n9eYKQfoZl9Dp6IsILTQ==
+"@aws-cdk/aws-sqs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.122.0.tgz#03e0c07a80ab33b38ba37b3eb6243f18a5599a91"
+  integrity sha512-ZamVuEfLMj8JpidjqbYR6jiAIvc8yl/WUoDS73nrypWFZf5G9IF7dDPMZ6NXGKnwF6WUD629UpUNgB7grmB4Qg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ssm@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.120.0.tgz#b57e0274e5949a5c8a63e6fda8a19886a91fad1c"
-  integrity sha512-x+4E1P2F5K88mjE99i3Nf1TyxFHrh4rHL/p2Ew1Q3d+8Z+JWqwTPHC95GSZUQeiXWDxlAofFgB4AKwnho4paEA==
+"@aws-cdk/aws-ssm@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.122.0.tgz#31e5707bc818d1166a858db6a5ddd527061006b0"
+  integrity sha512-yoB4tUeV8GgA2MylEMAXlJQUbD9mvOUoZk9zTEGmNyjhpTZBGB24YbBfeoqnq2Igh9PfAlNZkPtguGp/tPZVJQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kms" "1.120.0"
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-stepfunctions@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.120.0.tgz#2edb17cdc3ee20598a8be0859e38612cf2561a43"
-  integrity sha512-Iv1N0TmAUoBxPeQSxGeVElFoD4z7O3sSD+g2q5d7/pVfl1p+8yGVGHW8H+3PQwQJRlbh4fAacse5FU94AN4wlw==
+"@aws-cdk/aws-stepfunctions-tasks@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.122.0.tgz#707f6c7944381167192146350232737fa9f50b76"
+  integrity sha512-AFnttLbi9ZcRB/eSJ3DCWBj3v2NoTxlVidkmf0e11ewzJ3ML/PK21kqzhSqBLz2dEkh5U2alee3sXS/8WjObnQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.120.0"
-    "@aws-cdk/aws-events" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codebuild" "1.122.0"
+    "@aws-cdk/aws-dynamodb" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-eks" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/cfnspec@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.120.0.tgz#7bac5849e3e7adbce94ffbc5f0f6d96ad1d07975"
-  integrity sha512-8okwNc4h7mpLIaP4yOOtreIFM7EdnmVGXoPGTd8rnePaOil6WBsUVHQowxuoPXzKj/A0h/xTcQ1zWK0CG/cWcQ==
+"@aws-cdk/aws-stepfunctions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.122.0.tgz#4c1f69446306dbfc0d61b5c33ec8e2a2f97081a8"
+  integrity sha512-X7tAW2gtWRdwoIRPMUIoYnCGDgSyPZK8p3NpvmOX8BDocCTKJQcvp+x58nDHTGU0u9znpePd6hULA1A7OuCy+A==
+  dependencies:
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/cfnspec@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.122.0.tgz#c42b76668ba692cea6951e0a29a70399241e4f0e"
+  integrity sha512-41CyWYJLfWfQbJWONNwu1FBIsDfDn3r/0pukc+Bkrsmx2zcPRY/JW+THyFZCyG5x1lO6T4XfGRuF2DfCehLaOQ==
   dependencies:
     md5 "^2.3.0"
 
-"@aws-cdk/cloud-assembly-schema@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.120.0.tgz#aa8ba63f5fcb5d8f384bb848261e90b4c152af87"
-  integrity sha512-W8CfFYLekobHxQ4on/mygfx8HOFIYverUl0LzvNMxzjpvOl5JQVRYG1azDDLRFomuLvw/6RZpJas8nDUi0y4oA==
+"@aws-cdk/cloud-assembly-schema@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.122.0.tgz#8e6b86972bc662ac54e152566141a0a4678ee16a"
+  integrity sha512-xyVIaRZbQEoVI8VPbgreK18o0BVVthavn3zUKw6p+S1NF+FMgqatTLU0pq+bMLOHwI/zyNKuZs3KhBoMLyhZMA==
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
 
-"@aws-cdk/cloudformation-diff@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.120.0.tgz#fee8e28b81fc006e91e6ea8de876666b6c5b794a"
-  integrity sha512-vDE3BpB5Ch0iX+ygNoF/g/zFsyZsl/aQ6o21aS6d62UbU47FqNHlsLJpLMGQ8ErwjwdZbazSz1s2t12a9eOR7w==
+"@aws-cdk/cloudformation-diff@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.122.0.tgz#1661bf6adb7421a8702bbd2c71f36d2ea863db54"
+  integrity sha512-syTS6fPd0IASzsOGJUbZtpPzHhW0aTtoPauN4NK7T2ynyEGVMmdW5vikdWBt3Kg5mkTTVvxQix7r1aLiQyMYIw==
   dependencies:
-    "@aws-cdk/cfnspec" "1.120.0"
+    "@aws-cdk/cfnspec" "1.122.0"
     "@types/node" "^10.17.60"
     colors "^1.4.0"
     diff "^5.0.0"
@@ -727,46 +771,64 @@
     string-width "^4.2.2"
     table "^6.7.1"
 
-"@aws-cdk/core@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.120.0.tgz#4b20f779a6623010f49c06fa297878d2b29dc053"
-  integrity sha512-BLWySkl1CUhHnatztB15b1u4+t6RYPaq5bQrdClcJq6sqf8p95Sn57sdNSJVfw31+9+m28vWUwfd7p8JnRStmg==
+"@aws-cdk/core@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.122.0.tgz#726cee4802f49a16c1ec72d320ad33fa67191422"
+  integrity sha512-8yQmOH1e4YvL/MVIDQj2JS1YeijIePshP2fPw7X5iP4tdLcPcHPTXHXJAp2ARF7XL5u03juVENn/hG7G0B91nw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     "@balena/dockerignore" "^1.0.2"
     constructs "^3.3.69"
     fs-extra "^9.1.0"
     ignore "^5.1.8"
     minimatch "^3.0.4"
 
-"@aws-cdk/custom-resources@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.120.0.tgz#11a8fc94a769b947dfe04ec1f6715a85d3140a02"
-  integrity sha512-SjJAD9QQtkRCw3xow6bcTR9Bmn6lldlglbuN8/+JQE0tv+tZTJ3FfGCFR7wEGeni6kS9v7fnAmfTgZbgl7VL9A==
+"@aws-cdk/custom-resources@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.122.0.tgz#e4554dc9b4e3917a4f935ff3884d6bd1ccbca9ed"
+  integrity sha512-vdipr6cpCIYl0lokS0HQI3kY34mqpxns82+MzqYc95xZ7HPYOjnP0aKqL+UKIpaQsTVVUkOqfxZ9cXNdv04Xag==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-logs" "1.120.0"
-    "@aws-cdk/aws-sns" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
+    "@aws-cdk/aws-cloudformation" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/cx-api@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.120.0.tgz#a50cdb9703ca1e5047361c1fe2f6041f978b658e"
-  integrity sha512-ETlLjWyHwLEWEoggTCFs+BVEIFtgxAUHjkVkgYPfqnqFl29C6kQqgcXuOlIfRgisImRSQnWlzHf+6Tse5nR5Jw==
+"@aws-cdk/cx-api@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.122.0.tgz#431f3a5a7ec339fdfff0387e85f2e5956a43fb17"
+  integrity sha512-x2SPWc3RNBWi5UBdq/gZvW5He9X5NRb2j9pcBcUPhVSSEB7Fl5lqPU82q8mBy+76zHkfWILpLGJr/jNQ4ZRAeA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
     semver "^7.3.5"
 
-"@aws-cdk/region-info@1.120.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.120.0.tgz#c3efe5999fb75325f7efb8cfa447577aca8c7c40"
-  integrity sha512-DX315Ydn3+QgTodhyPZCQc2WvsKbQ7c/W44DdGv//zabZloTrXcXIeEGWkrUexJOpHPWqD7WLZsDm1uh3Ic4Og==
+"@aws-cdk/lambda-layer-awscli@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.122.0.tgz#ec3aedc6bc595e191fd8993f95b2c81cf3ec75b5"
+  integrity sha512-ecWutnWFluWYgAjGORiHUTvCCcD24FPl0b6NqT2Ex5vQmTXHCO4CdHncL0CIwQwNE6zGzQitTKEc3snumGVGng==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/lambda-layer-kubectl@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-kubectl/-/lambda-layer-kubectl-1.122.0.tgz#6e0b21f1843dcb89eaa47087591008e155b26272"
+  integrity sha512-TxZUaAUMCQbTeZPz8PWVOU/b/gMEHOoJ2AONNhYB/vDNHNBPdReBguCh6BLWYtIXlfWBrAJ3kluTmsZFGIGlvA==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/region-info@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.122.0.tgz#05dc2fe82c365dc6b458a5e1138faa833c578e19"
+  integrity sha512-6nFk66RE+PYh85aU07tA3TxsfKUHZZxnPITidwnyJYZ2OgimxMRIuWQce1bSLkZrcaQhachcJTJ1o8mF20kJmg==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -1083,32 +1145,36 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@24.0.0":
-  version "24.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-24.0.0.tgz#c0f07854ebd75fc422dabcfcf0847a8dd5f6b029"
-  integrity sha512-UE8fjn3rC//FQy9josmXrL+obPKIOj87xKbJIbRP68vub/9t4ttx2aQe2r3MS2s6g8BpvqoTkvx2xvbo4VcTaA==
+"@guardian/cdk@26.2.1":
+  version "26.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-26.2.1.tgz#e597a973b219401f17357666ba68d9198fa89ecf"
+  integrity sha512-AKSPhJURsBzBoFsCgOra8yWGltCqtYV9qcJIusQ+UiZsB+yOfD0u4TKZ7sUg5yNv9NEUMwj25CtY9/u+hmsT1w==
   dependencies:
-    "@aws-cdk/assert" "1.120.0"
-    "@aws-cdk/aws-apigateway" "1.120.0"
-    "@aws-cdk/aws-autoscaling" "1.120.0"
-    "@aws-cdk/aws-cloudwatch-actions" "1.120.0"
-    "@aws-cdk/aws-ec2" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.120.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.120.0"
-    "@aws-cdk/aws-events-targets" "1.120.0"
-    "@aws-cdk/aws-iam" "1.120.0"
-    "@aws-cdk/aws-kinesis" "1.120.0"
-    "@aws-cdk/aws-lambda" "1.120.0"
-    "@aws-cdk/aws-lambda-event-sources" "1.120.0"
-    "@aws-cdk/aws-rds" "1.120.0"
-    "@aws-cdk/aws-s3" "1.120.0"
-    "@aws-cdk/core" "1.120.0"
-    aws-sdk "^2.976.0"
+    "@aws-cdk/assert" "1.122.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch-actions" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-events-targets" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-lambda-event-sources" "1.122.0"
+    "@aws-cdk/aws-rds" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/aws-stepfunctions-tasks" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    aws-sdk "^2.996.0"
     chalk "^4.1.2"
     execa "^5.1.1"
-    git-url-parse "^11.5.0"
+    git-url-parse "^11.6.0"
     read-pkg-up "7.0.1"
-    yargs "^17.1.1"
+    yargs "^17.2.1"
 
 "@guardian/eslint-config-typescript@^0.6.1":
   version "0.6.1"
@@ -1851,20 +1917,20 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-cdk@1.120.0:
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.120.0.tgz#57f87edc760c0b30168e422a5e721f86a57c1da2"
-  integrity sha512-4QLZlagNcc/hV23SFEvo5izJSJZqugdVhdDDkizZ2JM/FUDmwZZGsTV79yyMiO4KAd0t74q4QxLWUDwRUbyt0g==
+aws-cdk@1.122.0:
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.122.0.tgz#2efa6d1b7c1474344b6c68dff52aa056591a70f9"
+  integrity sha512-AdWTa0Oxkcz51Cm6sdYwtTB0NQ32j8UW34W2C9Z2G5G8SMUSJd4tH+RS+XEHNaYyYLGaP+Gpvajt+cDviOIBjA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/cloudformation-diff" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
-    "@aws-cdk/region-info" "1.120.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cloudformation-diff" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     "@jsii/check-node" "1.33.0"
     archiver "^5.3.0"
-    aws-sdk "^2.848.0"
+    aws-sdk "^2.979.0"
     camelcase "^6.2.0"
-    cdk-assets "1.120.0"
+    cdk-assets "1.122.0"
     colors "^1.4.0"
     decamelize "^5.0.0"
     fs-extra "^9.1.0"
@@ -1881,10 +1947,25 @@ aws-cdk@1.120.0:
     yaml "1.10.2"
     yargs "^16.2.0"
 
-aws-sdk@^2.848.0, aws-sdk@^2.976.0:
+aws-sdk@^2.848.0:
   version "2.983.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.983.0.tgz#4c6d98d802b2cf159acbc105979b892b427b5fb3"
   integrity sha512-i4QMJt5hEYzhoDzmbo0v+aAuHQPXM6ah15GBKObbxwYxmzK9wjMG+FH3DiWZZHdFsf3C+p1zDg4rIr63jmOeBw==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.979.0, aws-sdk@^2.996.0:
+  version "2.1001.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1001.0.tgz#c4da256aa0058438ba611ae06fa850f4f7d63abc"
+  integrity sha512-DpmslPU8myCaaRUwMzB/SqAMtD2zQckxYwq3CguIv8BI+JHxDLeTdPCLfA5jffQ8k6dcvISOuiqdpwCZucU0BA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2138,13 +2219,13 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-cdk-assets@1.120.0:
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.120.0.tgz#0d4163b90985aec1ff9e003f45b7cadd2cd3ca35"
-  integrity sha512-hPmQL3hhNuAhLcQnRTUDW/LJ7QYobivJhpHhTIJxxEM9XfgRZRWB+4UKsLG2Aak3fHv2FoZ3AzNA6nSfN7uwsA==
+cdk-assets@1.122.0:
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.122.0.tgz#dd5f58b11499021a72cb16c16b0c01be4be0bc12"
+  integrity sha512-AbJgrROkwj0hmFLcCtqxJLTAVqFyMP+rIS9XM9nfrEIgoNzJnmy1KgJneuXNA9U7dquSFlTPYfAoy2UCTrryBw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.120.0"
-    "@aws-cdk/cx-api" "1.120.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     glob "^7.1.7"
@@ -3268,10 +3349,10 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
-git-url-parse@^11.5.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.5.0.tgz#acaaf65239cb1536185b19165a24bbc754b3f764"
-  integrity sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==
+git-url-parse@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
+  integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
   dependencies:
     git-up "^4.0.0"
 
@@ -6602,10 +6683,10 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.1:
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz#c2a8091564bdb196f7c0a67c1d12e5b85b8067ba"
-  integrity sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==
+yargs@^17.2.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
## What does this change?
This change updates @guardian/cdk dependency to 26.2.1 with requisite changes to keep everything working correctly.

## How to test
run /script/test and fix any errors
Deploy to CODE

## How can we measure success?
keeping things up-to-date

## Have we considered potential risks?
this change mitigates risks of cdk version becoming too far out of date. Main risk is that there is some unknown change in the latest versions of cdk which we havent captured in our testing, the greater risk is not to update though.