### PR TITLE
Update sbt-riffraff-artifact

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 // The Typesafe repository
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 


### PR DESCRIPTION
## What does this change?
Update sbt-riffraff-artifact to avoid warnings from AWS SDK on sbt startup.
