### PR TITLE
Update to sbt version 1.5.6 and Play version 2.8.8

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,14 +15,14 @@
     <p>For the sake of everyones sanity, this page lists the endpoints that are available to experiment with.</p>
 
     <ul>
-        <li><a href="@routes.Api.instanceList()">Instances</a> - filter using any key as a query param e.g.
-            <a href="@(s"${routes.Api.instanceList()}?vendor=aws")">vendor=aws</a> or a more complex example
-            <a href="@(s"${routes.Api.instanceList()}?mainclasses~=soulmates.*&stage!=PROD")">mainclasses~=soulmates.*&stage!=PROD</a>
+        <li><a href="@routes.Api.instanceList">Instances</a> - filter using any key as a query param e.g.
+            <a href="@(s"${routes.Api.instanceList}?vendor=aws")">vendor=aws</a> or a more complex example
+            <a href="@(s"${routes.Api.instanceList}?mainclasses~=soulmates.*&stage!=PROD")">mainclasses~=soulmates.*&stage!=PROD</a>
         </li>
-        <li><a href="@routes.Api.securityGroupList()">Security Groups</a></li>
-        <li><a href="@routes.Api.roleList()">Roles</a></li>
-        <li><a href="@routes.Api.stackList()">Stacks</a></li>
-        <li><a href="@routes.Api.appList()">Apps</a> - again, filters work with either key</li>
+        <li><a href="@routes.Api.securityGroupList">Security Groups</a></li>
+        <li><a href="@routes.Api.roleList">Roles</a></li>
+        <li><a href="@routes.Api.stackList">Stacks</a></li>
+        <li><a href="@routes.Api.appList">Apps</a> - again, filters work with either key</li>
     </ul>
 
     <h2>Query parameters</h2>

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "prism"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.13.3"
+ThisBuild / scalaVersion := "2.13.3"
 
 resolvers ++= Seq(
   "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
@@ -17,13 +17,13 @@ val awsVersionOne = "1.11.918"
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
   .settings(
-    packageName in Universal := normalizedName.value,
+    Universal / packageName := normalizedName.value,
     fileDescriptorLimit := Some("16384"),
     maintainer := "Guardian Developers <dig.dev.software@theguardian.com>",
-    topLevelDirectory in Universal := Some(normalizedName.value),
+    Universal / topLevelDirectory := Some(normalizedName.value),
     riffRaffPackageName := s"devx::${name.value}",
     riffRaffManifestProjectName := riffRaffPackageName.value,
-    riffRaffPackageType := (packageBin in Debian).value,
+    riffRaffPackageType := (Debian / packageBin).value,
     riffRaffArtifactResources  := Seq(
       riffRaffPackageType.value -> s"${name.value}/${name.value}.deb",
       baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
@@ -77,10 +77,10 @@ lazy val root = (project in file("."))
       "-Xfatal-warnings",
       "-Xcheckinit"
     ),
-    scalacOptions in Test ++= Seq("-Yrangepos")
+    Test / scalacOptions ++= Seq("-Yrangepos")
   )
 
-javaOptions in Universal ++= Seq(
+Universal / javaOptions ++= Seq(
   "-Dpidfile.path=/dev/null",
   "-J-XX:MaxRAMPercentage=60",
   "-J-XX:InitialRAMPercentage=60",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 


### PR DESCRIPTION
## What does this change?

This PR updates `sbt` to version `1.5.6`. 

This version of `sbt` was incompatible with Play `2.8.2`, so I have also bumped the Play version to `2.8.8` and made a few small changes to keep things working.

## How to test

I've confirmed that this change can be [successfully deployed to `CODE`](https://riffraff.gutools.co.uk/deployment/view/10f12972-ca84-4d67-acff-ce9aa50caba7).

## How can we measure success?

* All functionality should work as before
* The `sbt` [version](https://github.com/sbt/sbt/releases/tag/v1.5.6) is no longer vulnerable to [Remote code injection in Log4j](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)

## Have we considered potential risks?

This should be pretty low risk due to testing described above.