### PR TITLE
feat: Enable access logging

### DIFF
--- a/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism-ec2-app.test.ts.snap
@@ -34,6 +34,11 @@ Object {
       "Description": "Amazon Machine Image ID for the app prism. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
+    "AccessLoggingBucket": Object {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "DistributionBucketName": Object {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -267,11 +272,7 @@ dpkg -i /prism/prism.deb",
                 "Fn::Join": Array [
                   "",
                   Array [
-                    "arn:aws:dynamodb:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:dynamodb:eu-west-1:",
                     Object {
                       "Ref": "AWS::AccountId",
                     },
@@ -518,11 +519,7 @@ dpkg -i /prism/prism.deb",
                 "Fn::Join": Array [
                   "",
                   Array [
-                    "arn:aws:kinesis:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     Object {
                       "Ref": "AWS::AccountId",
                     },
@@ -554,17 +551,7 @@ dpkg -i /prism/prism.deb",
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -693,6 +680,20 @@ dpkg -i /prism/prism.deb",
             "Key": "deletion_protection.enabled",
             "Value": "true",
           },
+          Object {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          Object {
+            "Key": "access_logs.s3.bucket",
+            "Value": Object {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          Object {
+            "Key": "access_logs.s3.prefix",
+            "Value": "prism",
+          },
         ],
         "Scheme": "internal",
         "SecurityGroups": Array [
@@ -805,11 +806,7 @@ dpkg -i /prism/prism.deb",
                 "Fn::Join": Array [
                   "",
                   Array [
-                    "arn:aws:ssm:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     Object {
                       "Ref": "AWS::AccountId",
                     },
@@ -935,11 +932,7 @@ dpkg -i /prism/prism.deb",
             "Fn::Join": Array [
               "",
               Array [
-                "arn:aws:sns:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 Object {
                   "Ref": "AWS::AccountId",
                 },

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -68,6 +68,9 @@ export class PrismEc2App extends GuStack {
           }),
         },
       ],
+      accessLogging: {
+        enabled: true,
+      },
     });
 
     // The pattern does not currently offer support for customising healthchecks via props

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -20,7 +20,13 @@ export class PrismEc2App extends GuStack {
   };
 
   constructor(scope: App, id: string, props: GuStackProps) {
-    super(scope, id, props);
+    super(scope, id, {
+      ...props,
+      env: {
+        // region is required to enable access logging at the load balancer
+        region: "eu-west-1",
+      },
+    });
 
     const pattern = new GuPlayApp(this, {
       ...PrismEc2App.app,
@@ -70,6 +76,7 @@ export class PrismEc2App extends GuStack {
       ],
       accessLogging: {
         enabled: true,
+        prefix: PrismEc2App.app.app,
       },
     });
 


### PR DESCRIPTION
Requires #291.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We want to understand exactly how RIff-Raff interacts with Prism to, ultimately, remove as much of the coupling as possible. This follows an issue where RIff-Raff 503'd because it struggled to process a response from Prism (https://github.com/guardian/riff-raff/pull/675).

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Although the SSM parameter on `/account/services/access-logging/bucket` exists, the bucket it refers to does not 😱 ! What is the best way to create this bucket with IaC?