### PR TITLE
Add more metadata to /apps-with-cdk-version

### DIFF
--- a/app/agent/model.scala
+++ b/app/agent/model.scala
@@ -24,7 +24,9 @@ trait IndexedItemWithCoreTags extends
   IndexedItemWithGuCdkVersion with
   IndexedItemWithStage with
   IndexedItemWithStack with
-  IndexedItemWithPatternName
+  IndexedItemWithPatternName {
+  val awsRuntime: String
+}
 
 trait IndexedItemWithApp extends IndexedItem {
   val app: List[String] = Nil

--- a/app/collectors/instance.scala
+++ b/app/collectors/instance.scala
@@ -185,6 +185,8 @@ case class Instance(
                  specification:Option[InstanceSpecification]
                 ) extends IndexedItemWithCoreTags {
 
+  override val awsRuntime: String = "EC2"
+
   def callFromArn: String => Call = arn => routes.Api.instance(arn)
   override lazy val fieldIndex: Map[String, String] = super.fieldIndex ++ Map("dnsName" -> dnsName) ++ stage.map("stage" ->)
 

--- a/app/collectors/lambda.scala
+++ b/app/collectors/lambda.scala
@@ -93,5 +93,6 @@ case class Lambda(
   override val stage: Option[String],
   override val stack: Option[String]
 ) extends IndexedItemWithCoreTags {
+  override val awsRuntime: String = "Lambda"
   override def callFromArn: (String) => Call = arn => routes.Api.instance(arn)
 }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -3,6 +3,7 @@ package controllers
 import agent._
 import collectors._
 import conf.PrismConfiguration
+import data.Owners
 import play.api.http.Status
 import play.api.libs.json.Json._
 import play.api.libs.json._
@@ -259,7 +260,9 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
           "stack" -> i.stack.getOrElse("unknown"),
           "stage" -> i.stage.getOrElse("unknown"),
           "guCdkVersion" -> i.guCdkVersion.getOrElse("n/a"),
-          "guCdkPatternName" -> i.guCdkPatternName.getOrElse("unknown")
+          "guCdkPatternName" -> i.guCdkPatternName.getOrElse("unknown"),
+          "awsRuntime" -> i.awsRuntime,
+          "stackOwner" -> Owners.forStack(i.stack.getOrElse("unknown"), i.stage, Some(app)).id
         )
       )
     }


### PR DESCRIPTION
## What does this change?

This PR adds some more metadata to the `/apps-with-cdk-version` endpoint. This endpoint supplies the data for our [GuCDK adoption dashboard](https://metrics.gutools.co.uk/d/AysWSbQMk/devx-guardian-cdk-adoption?orgId=1), so adding this metadata will help us to surface more useful information. For example, this allows us to more easily answer questions likee:

* How many EC2 vs Lambda based apps are left to migrate? 
* Which teams own the EC2-based services that still need to be migrated to GuCDK?

## How to test

I've deployed this to `CODE` and confirmed that the new data is coming through as expected.