### PR TITLE
Update Owners.scala

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -45,6 +45,7 @@ object Owners extends Owners {
     "digitalcms.dev" -> SSA("flexible-secondary"),
     "digitalcms.dev" -> SSA("workflow"),
     "digitalcms.dev" -> SSA("cms-fronts"),
+    "digitalcms.dev" -> SSA("fronts"),
     "digitalcms.dev" -> SSA("elk-new"),
     "digitalcms.dev" -> SSA("media-service"),
     "digitalcms.dev" -> SSA("grid-elasticsearch"),


### PR DESCRIPTION
Describe owner of the `fronts` stack. The lambdas are deployed to the `cms-fronts` account, which `digitalcms.dev` own.