### PR TITLE
Re-enable cloudformation crawling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ dist
 Gemfile.lock
 .rakeTasks
 *.iml
+
+.bloop/
+.bsp/
+.metals/
+.vscode/
+project/.bloop/
+project/metals.sbt
+project/project/

--- a/app/conf/context.scala
+++ b/app/conf/context.scala
@@ -138,7 +138,8 @@ object PrismConfiguration {
       "reservation" -> fastCrawlRate,
       "instance" -> fastCrawlRate,
       "images" -> fastCrawlRate,
-      "data" -> fastCrawlRate
+      "data" -> fastCrawlRate,
+      "cloudformationStacks" -> slowCrawlRate,
     ).withDefaultValue(defaultCrawlRate)
   }
   val lowPriorityRegionCrawlRate: Map[String, CrawlRate] = Map.empty.withDefaultValue(slowCrawlRate)

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -32,12 +32,9 @@ class Prism(prismConfiguration: PrismConfiguration)(actorSystem: ActorSystem) {
   val rdsAgent = new CollectorAgent[Rds](new RdsCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
   val vpcAgent = new CollectorAgent[Vpc](new VpcCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
 
-  // We do not currently start this agent because it causes us to hit AWS rate limits.
-  // Ultimately, this prevents new instances from coming into service reliably.
-  // To re-enable this functionality, add cloudformationStackAgent to allAgents.
   val cloudformationStackAgent = new CollectorAgent[CloudformationStack](new CloudformationStackCollectorSet(accounts), sourceStatusAgent, lazyStartup)(actorSystem)
 
   val allAgents = Seq(instanceAgent, lambdaAgent, dataAgent, securityGroupAgent, imageAgent, launchConfigurationAgent,
     serverCertificateAgent, acmCertificateAgent, route53ZoneAgent, elbAgent, bucketAgent, reservationAgent, rdsAgent,
-    vpcAgent)
+    vpcAgent, cloudformationStackAgent)
 }


### PR DESCRIPTION
This collector was introduced [here](https://github.com/guardian/prism/pull/197).

But [quickly disabled](https://github.com/guardian/prism/pull/228) as it was hitting rate limits.

The feature would be useful for some CDK tracking we are doing andI wonder if using the 'slow' (once per day) crawl rate will help here.