### PR TITLE
Include Cloudformation template metadata

### DIFF
--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -72,8 +72,6 @@ object model {
   implicit val vpcWriter: Writes[Vpc] = Json.writes[Vpc]
 
   implicit val cloudformationStackDriftInformationWriter: Writes[CloudformationStackDriftInformation] = Json.writes[CloudformationStackDriftInformation]
-  implicit val cloudformationStackOutput: Writes[CloudformationStackOutput] = Json.writes[CloudformationStackOutput]
-  implicit val cloudformationStackParameter: Writes[CloudformationStackParameter] = Json.writes[CloudformationStackParameter]
   implicit val cloudformationStackResource: Writes[CloudformationStackResource] = Json.writes[CloudformationStackResource]
   implicit val cloudformationStackWriter: Writes[CloudformationStack] = Json.writes[CloudformationStack]
 


### PR DESCRIPTION
*Follows: https://github.com/guardian/prism/pull/334.*

This is of interest for CDK tracking, as we plan to do this via template metadata. As part of this, I've removed some stuff to simplify and make sure this is an API-request-net-neutral™℠®© change.

Note, we should wait to see if the previous PR solves the rate limiting issue. Failing that, we may have to explore some kind of (exponential) back-off strategy to better handle the limits here.
