### PR TITLE
Add Gemfile.lock for marauder dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist
 /RUNNING_PID
 /.settings
 *.gem
-Gemfile.lock
 .rakeTasks
 *.iml
 

--- a/marauder/Gemfile.lock
+++ b/marauder/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    commander (4.6.0)
+      highline (~> 2.0.0)
+    highline (2.0.3)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    multi_xml (0.6.0)
+    net-ssh (7.0.1)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  commander
+  httparty
+  net-ssh
+
+BUNDLED WITH
+   2.3.7


### PR DESCRIPTION
## What does this change?
Adds a lock file for marauder's dependencies because that's best practice, and without one, Snyk will require installation of gems at runtime to check for vulnerabilities. The caveat is that I am not versed in the ruby ecosystem, so feel free to point out any missteps.

## How to test
I don't actually know how to test this works as expected...
