### PR TITLE
Add subnet scope to VPC reports

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.7.1

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,5 +1,8 @@
 regions: [eu-west-1]
 stacks: [deploy]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   cloudformation:
     type: cloud-formation


### PR DESCRIPTION
A subnet is considered private unless it has an internet gateway associated to its route table.

This is helpful for us to better understand the shape of VPCs across the dept - particularly the number of VPCs that do not have any private subnets.