### PR TITLE
fix (snyk): prune duplicates to prevent hanging in workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,5 +12,6 @@ jobs:
       DEBUG: true
       ORG: guardian-devtools
       SKIP_NODE: false
+      PRUNE_DUPLICATES: true
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?
Post-merge we observed that the workflow run was hanging, which is a known issue for larger SBT projects. We have an open support ticket, but in the meantime pruning duplicate sub-dependencies often helps.