### PR TITLE
Fix for misleading entry gu, when querying sources/accounts

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -84,13 +84,12 @@ class Api (cc: ControllerComponents, prismDataStore: Prism, prismConfiguration: 
 
     def sourceAccounts: Action[AnyContent] = Action.async { implicit request =>
       ApiResult.noSource {
-        val accounts = prismDataStore.sourceStatusAgent.sources.data.map { source =>
-          val accountName = source.latest.origin.account
-          val accountNumber = source.latest.origin match {
-            case a: AmazonOrigin => a.accountNumber
-            case _ => None
+        val accounts = prismDataStore.accounts.all.collect {
+          case result: AmazonOrigin => {
+            val accountName = result.account
+            val accountNumber = result.accountNumber
+            AWSAccount(accountNumber, accountName)
           }
-          AWSAccount(accountNumber, accountName)
         }.toList.distinct
         Json.toJson(accounts)
       }


### PR DESCRIPTION
Fix for misleading entry gu, when querying sources/accounts. This will not show any more.

Co-authored-by Akash and Nic

## What does this change?

Only entries of type AmazonOrigin will be used to build json result for the query sources/accounts

## How to test

https://prism.gutools.co.uk/sources/accounts
should not yield
accountName "gu"
any more

## Have we considered potential risks?

Any side effects would only result in problems within devX, so we feel we can go ahead.
