### PR TITLE
Use getCallerIdentity instead of getUser

### DIFF
--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -23,13 +23,11 @@ import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
 class Accounts(prismConfiguration: PrismConfiguration) extends Logging {
-  val ArnIamAccountExtractor: Regex = """arn:aws:iam::(\d+):user.*""".r
   val all:Seq[Origin] = (prismConfiguration.accounts.aws.list ++ prismConfiguration.accounts.amis.list).map { awsOrigin =>
     Try {
       val stsClient = StsClient.builder().credentialsProvider(awsOrigin.credentials.provider)
         .region(Region.AWS_GLOBAL)
         .build
-
       val accountNumber = stsClient.getCallerIdentity.account()
       awsOrigin.copy(accountNumber = Some(accountNumber))
     } recover {

--- a/app/agent/origin.scala
+++ b/app/agent/origin.scala
@@ -26,13 +26,12 @@ class Accounts(prismConfiguration: PrismConfiguration) extends Logging {
   val ArnIamAccountExtractor: Regex = """arn:aws:iam::(\d+):user.*""".r
   val all:Seq[Origin] = (prismConfiguration.accounts.aws.list ++ prismConfiguration.accounts.amis.list).map { awsOrigin =>
     Try {
-      val iamClient = IamClient.builder
-        .credentialsProvider(awsOrigin.credentials.provider)
-        .region(AWS.connectionRegion)
+      val stsClient = StsClient.builder().credentialsProvider(awsOrigin.credentials.provider)
+        .region(Region.AWS_GLOBAL)
         .build
 
-      val ArnIamAccountExtractor(derivedAccountNumber) = iamClient.getUser.user.arn
-      awsOrigin.copy(accountNumber = Some(derivedAccountNumber))
+      val accountNumber = stsClient.getCallerIdentity.account()
+      awsOrigin.copy(accountNumber = Some(accountNumber))
     } recover {
       case NonFatal(e) =>
         if (awsOrigin.accountNumber.isDefined) awsOrigin else {


### PR DESCRIPTION
Use getCallerIdentity instead of getUser to enable better results while running locally (because of a permission problem).

Co-authored-by Akash and Nic

## What does this change?

Switching form getUser to getCallerIdentity will ensure accountNumber will show when running locally because of an permission problem with aws credentials preventing this

## How to test

http://localhost:9000/sources/accounts
Should not return ???????? for accountNumber any more

## Have we considered potential risks?

Any side effects would only result in problems within devX, so we feel we can go ahead.