### PR TITLE
feat: Add a request logger

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -19,7 +19,10 @@ class AppComponents(context: ApplicationLoader.Context)
     with Logging {
 
   override def httpFilters: Seq[EssentialFilter] = {
-    super.httpFilters :+ gzipFilter
+    super.httpFilters ++ Seq(
+      gzipFilter,
+      new RequestLoggingFilter(materializer)
+    )
   }
 
   val prismConfig = new PrismConfiguration(configuration)

--- a/app/RequestLoggingFilter.scala
+++ b/app/RequestLoggingFilter.scala
@@ -1,0 +1,67 @@
+import akka.stream.Materializer
+import net.logstash.logback.marker.Markers.appendEntries
+import play.api.mvc.{Filter, RequestHeader, Result}
+import play.api.MarkerContext
+import utils.Logging
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
+
+class RequestLoggingFilter(override val mat: Materializer)(implicit ec: ExecutionContext) extends Filter with Logging {
+  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+    val start = System.currentTimeMillis()
+    val result = next(rh)
+
+    result onComplete {
+      case Success(response) =>
+        val duration = System.currentTimeMillis() - start
+        logSuccess(rh, response, duration)
+
+      case Failure(err) =>
+        val duration = System.currentTimeMillis() - start
+        logFailure(rh, err, duration)
+    }
+
+    result
+  }
+
+  private def logSuccess(request: RequestHeader, response: Result, duration: Long): Unit = {
+    val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
+    val referer = request.headers.get("Referer").getOrElse("")
+    val userAgent = request.headers.get("User-Agent").getOrElse("")
+    val length = response.header.headers.getOrElse("Content-Length", 0)
+
+    val mandatoryMarkers = Map(
+      "origin" -> originIp,
+      "referrer" -> referer,
+      "method" -> request.method,
+      "status" -> response.header.status,
+      "duration" -> duration,
+      "requestUri" -> request.uri,
+      "userAgent" -> userAgent
+    )
+
+    val markers = MarkerContext(appendEntries(mandatoryMarkers.asJava))
+    log.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ${response.header.status} $length "$referer" ${duration}ms""")(markers)
+  }
+
+  private def logFailure(request: RequestHeader, throwable: Throwable, duration: Long): Unit = {
+    val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
+    val referer = request.headers.get("Referer").getOrElse("")
+    val userAgent = request.headers.get("User-Agent").getOrElse("")
+
+    val mandatoryMarkers = Map(
+      "origin" -> originIp,
+      "referrer" -> referer,
+      "method" -> request.method,
+      "duration" -> duration,
+      "requestUri" -> request.uri,
+      "userAgent" -> userAgent
+    )
+
+    val markers = MarkerContext(appendEntries(mandatoryMarkers.asJava))
+    log.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ERROR "$referer" ${duration}ms""")(markers)
+    log.error(s"Error for ${request.method} ${request.uri}", throwable)
+  }
+}


### PR DESCRIPTION
A variant of https://github.com/guardian/prism/pull/292.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

It will be useful to know how Prism is accessed. In this change, we add a filter to log each request. The log lines have some markers, so we can interrogate them more easily in Central ELK.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Interact with Prism CODE
- View [logs in Central ELK](https://logs.gutools.co.uk/s/devx/goto/29072010-4bb5-11ed-a02a-2d44512a4a41)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We know which endpoints are in use.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

N/A

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/836140/195816659-55c407da-c151-4f0f-9ded-2f69b2f2a4bc.png)
