### PR TITLE
Upgrade Scala version to 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "prism"
 
 version := "1.0-SNAPSHOT"
 
-ThisBuild / scalaVersion := "2.13.9"
+ThisBuild / scalaVersion := "2.13.10"
 
 resolvers ++= Seq(
   "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",


### PR DESCRIPTION
## What does this change?

This follows out own advice and upgrade to 2.13.10 to avoid the vulnerability:

https://www.cve.org/CVERecord?id=CVE-2022-36944