### PR TITLE
Remove explicit bucket from riff-raff.yml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,7 +19,5 @@ deployments:
         BuiltBy: amigo
   prism:
     type: autoscaling
-    parameters:
-      bucket: deploy-tools-dist
     dependencies:
       - cloudformation


### PR DESCRIPTION
### Why are you making this change?

It is preferable to omit the bucket from riff-raff.yml if the AWS account deployed from has the necessary SSM parameters specifying the dist bucket location.

In this case the Baton AWS account has the SSM parameter `/account/services/artifact.bucket` set to `deploy-tools-dist` so the explicit config is unnecessary.

Note: this change is also used to check a riff-raff change in https://github.com/guardian/riff-raff/pull/885 to allow ommision of `bucketSsmLookup` to reduce verbosity.