### PR TITLE
Fix to allow Scala Steward to monitor dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,3 +89,10 @@ Universal / javaOptions ++= Seq(
   s"-J-Xlog:gc*:file=/var/log/${packageName.value}/gc.log:time:filecount=5,filesize=1024K"
 )
 
+/*
+ * This is required for Scala Steward to run until SBT plugins all migrated to scala-xml 2.
+ * See https://github.com/scala-steward-org/scala-steward/blob/13d63e8ae98a714efcdac2c7af18f004130512fa/project/plugins.sbt#L16-L19
+ */
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
Recent Scala Steward runs have been failing because of incompatibilities between versions of scala-xml.

Eg. https://github.com/guardian/scala-steward-public-repos/actions/runs/3378212621/jobs/5608120855#step:5:765
![image](https://user-images.githubusercontent.com/1722550/199521613-f8084efb-5d37-4944-be75-b293c7c05dd7.png)
