### PR TITLE
chore: Tune Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,9 @@ updates:
     commit-message:
       prefix: "chore(deps): "
     directory: '/cdk'
-    # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
+    # The version of AWS CDK libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:
       - dependency-name: "aws-cdk"
-      - dependency-name: "@aws-cdk/*"
+      - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"


### PR DESCRIPTION
## What does this change?
Ignores AWS CDK based libraries.

---

Closes #511.
Closes #512.
Closes #516.