### PR TITLE
Test focal image with updated cdk-base recipe from amigo code

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
       amiEncrypted: true
       amiTags:
         Recipe: arm64-focal-java11-deploy-infrastructure
-        AmigoStage: PROD
+        AmigoStage: CODE
         BuiltBy: amigo
   prism:
     type: autoscaling


### PR DESCRIPTION
## What does this change?

Testing https://amigo.code.dev-gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure/bakes/1

This bake uses the updated AMIgo CODE recipe for cdk-base:

https://github.com/guardian/amigo/pull/1066

Now Deployed, not yet tested ❌