### PR TITLE
Test jammy image with updated cdk-base recipe from amigo code

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
       amiParameter: AMIPrism
       amiEncrypted: true
       amiTags:
-        Recipe: arm64-focal-java11-deploy-infrastructure
+        Recipe: arm64-jammy-java11-deploy-infrastructure
         AmigoStage: CODE
         BuiltBy: amigo
   prism:


### PR DESCRIPTION
## What does this change?

Testing https://amigo.code.dev-gutools.co.uk/recipes/arm64-jammy-java11-deploy-infrastructure/bakes/1

This bake uses the updated AMIgo CODE recipe for cdk-base:

https://github.com/guardian/amigo/pull/1066

Not Deployed and tested yet: ❌