### PR TITLE
[DO NOT MERGE] Use arm64-focal-java11-deploy-infrastructure from CODE

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
       amiEncrypted: true
       amiTags:
         Recipe: arm64-focal-java11-deploy-infrastructure
-        AmigoStage: PROD
+        AmigoStage: CODE
         BuiltBy: amigo
   prism:
     type: autoscaling


### PR DESCRIPTION
## What does this change?

In order to test https://github.com/guardian/amigo/pull/1080, we are deploying an instance based on this build https://riffraff.gutools.co.uk/deployment/view/8ba89665-78d2-4ec4-80fb-d7ed2b1953b6, and this bake: https://amigo.code.dev-gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure/bakes/2.
