### PR TITLE
Add an owner for editorial-feeds stack

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -56,6 +56,7 @@ object Owners extends Owners {
     "digitalcms.dev" -> SSA("media-service"),
     "digitalcms.dev" -> SSA("grid-elasticsearch"),
     "digitalcms.dev" -> SSA("composer"),
+    "digitalcms.dev" -> SSA("editorial-feeds"),
     "digital.investigations" -> SSA("pfi"),
     "digital.investigations" -> SSA("pfi-giant"),
     "digital.investigations" -> SSA("pfi-playground"),


### PR DESCRIPTION
## What does this change?

DevX are currently receiving emails about out of date AMIs in the `editorial-feeds` stack; this is happening because the stack has no owner in Prism. This PR adds the necessary config to send these warnings to the correct team.