### PR TITLE
fix(s3): Handle case where we don't have access to a bucket

### DIFF
--- a/app/collectors/bucket.scala
+++ b/app/collectors/bucket.scala
@@ -116,6 +116,18 @@ object Bucket extends Logging {
             e
           )
           None
+
+        /*
+        Reaching this case means that the bucket exists, but the user does not have access to it.
+        For example, the bucket's policy might be set to only allow s3:* access from a specific IP address.
+         */
+        case e: S3Exception
+            if e.awsErrorDetails().errorCode == "AccessDenied" =>
+          log.warn(
+            s"AccessDenied for $bucketName in account ${origin.account}",
+            e
+          )
+          None
         case NonFatal(t) =>
           throw new IllegalStateException(
             s"Failed when building info for bucket $bucketName",


### PR DESCRIPTION
## What does this change?
We've encountered a bucket where the policy is set to deny `s3:*` if the request does not originate from a specific IP address.

Whilst this scenario is quite rare, we should handle it so that the healthcheck can pass.

Log at warn level for visibility.

## How to test
Easiest would be to [deploy `main` to CODE](https://riffraff.gutools.co.uk/deployment/history?projectName=devx%3A%3Aprism&page=1), observe a failing deploy, then [deploy this branch to CODE](https://riffraff.gutools.co.uk/deployment/view/f64d8c6d-35c1-40f9-be26-c844c4cc768d) and observe a successful deploy.

[Prism's healthcheck](https://github.com/guardian/prism/blob/00756c0f36192fcbe34ec30c42dc0186d921b0b0/app/controllers/Api.scala#L131-L150) is such that it'll only pass if it is able to crawl every resource. The healthcheck on `main` is failing because we're [`throw`ing](https://github.com/guardian/prism/blob/00756c0f36192fcbe34ec30c42dc0186d921b0b0/app/collectors/bucket.scala#L119-L124) when we encounter a bucket with `AccessDenied`. In this branch, we explicitly handle this scenario and allow the healthcheck to pass.

## How can we measure success?
Prism can be reliably deployed again, unblocking the open PRs waiting to be merged.
