### PR TITLE
chore(deps): Use the latest versions of AWS SDKs for Java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ resolvers ++= Seq(
   "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-releases"
 )
 
-val awsVersion = "2.20.147"
-val awsVersionOne = "1.12.577"
+val awsVersion = "2.21.15"
+val awsVersionOne = "1.12.581"
 
 lazy val root = (project in file("."))
   .enablePlugins(


### PR DESCRIPTION
## What does this change?
Update AWS SDKs to their latest version to resolve a high vulnerability reported by Snyk.

### Shouldn't Scala Steward have done this?
In theory, yes. However according to [their FAQs](https://github.com/scala-steward-org/scala-steward/blob/main/docs/faq.md):

> Scala Steward first proposes an update to the latest patch version at the same minor and major version. If the dependency is already on the latest patch version, it proposes an update to the latest minor version at the same major version.
> – https://github.com/scala-steward-org/scala-steward/blob/main/docs/faq.md

That is, for the v2 SDK, Scala Steward would only move to the next minor version once we are on the latest patch version. Given the AWS SDK sometimes sees multiple patch versions a day, it's unlikely we'll meet this requirement. Doing it manually is simpler.