### PR TITLE
Upgrade to play 3.0.0

### DIFF
--- a/app/RequestLoggingFilter.scala
+++ b/app/RequestLoggingFilter.scala
@@ -1,4 +1,4 @@
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import net.logstash.logback.marker.Markers.appendEntries
 import play.api.mvc.{Filter, RequestHeader, Result}
 import play.api.MarkerContext

--- a/app/agent/collector.scala
+++ b/app/agent/collector.scala
@@ -1,9 +1,9 @@
 package agent
 
-import akka.actor.ActorSystem
-import akka.agent.Agent
+import org.apache.pekko.actor.ActorSystem
 import net.logstash.logback.marker.Markers
 import org.joda.time.DateTime
+import org.apache.pekko.agent.Agent
 import utils._
 
 import scala.collection.mutable

--- a/app/controllers/Prism.scala
+++ b/app/controllers/Prism.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import agent.{Accounts, CollectorAgent, SourceStatusAgent}
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import collectors._
 import conf.PrismConfiguration
 import utils.StopWatch

--- a/app/pekko/gu/agent/Agent.scala
+++ b/app/pekko/gu/agent/Agent.scala
@@ -15,11 +15,11 @@
 /** Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
   */
 
-package akka.agent
+package org.apache.pekko.agent
 
 import scala.concurrent.stm._
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import akka.util.{SerializedSuspendableExecutionContext}
+import org.apache.pekko.util.{SerializedSuspendableExecutionContext}
 
 object Agent {
 

--- a/app/utils/ScheduledAgent.scala
+++ b/app/utils/ScheduledAgent.scala
@@ -1,11 +1,11 @@
 package utils
 
-import akka.actor.{ActorSystem, Cancellable}
-import akka.agent.Agent
+import org.apache.pekko.actor.{ActorSystem, Cancellable}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import org.joda.time.{DateTime, Interval, LocalDate, LocalTime}
+import org.apache.pekko.agent.Agent
 
 import scala.concurrent.ExecutionContext
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,7 +21,7 @@ collectorAgent {
   }
 }
 
-akka {
+pekko {
   log-dead-letters-during-shutdown = off
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 


### PR DESCRIPTION
The dependency PR upgrading to play 3.0.0 fails because you have to migrate akka to pekko manually
[Doc Migration to play 3.0. akka to pekko](https://medium.com/xworks-techinsights/akka-to-pekko-migration-step-by-step-cca64bc61016)

## What does this change?

Upgrade to play 3.0.0

## How to test

Deployed to and checked on code (https://prism.code.dev-gutools.co.uk/)
