### PR TITLE
As of Play 3.0, groupId has changed to org.playframework;

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,10 @@ lazy val root = (project in file("."))
       "com.gu" % "kinesis-logback-appender" % "2.1.1",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.3"
     ),
+    excludeDependencies ++= Seq(
+      // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
+      ExclusionRule(organization = "com.typesafe.play")
+    ),
     scalacOptions ++= List(
       "-encoding",
       "utf8",


### PR DESCRIPTION
Exclude transitive dependencies to the old artifacts

## What does this change?

Ashleigh pointed to me to an
[issue in the play-json-extensions](https://github.com/bizzabo/play-json-extensions/issues/94)
I added the excludeDependencies suggested, but am not 100% sure if this is needed since
sbt dependencyTree | grep ':play_'
[info]   | | +-org.playframework:play_2.13:3.0.0 [S]
[info]   | +-org.playframework:play_2.13:3.0.0 [S]
[info]   | +-org.playframework:play_2.13:3.0.0 [S]
[info]   | | +-org.playframework:play_2.13:3.0.0 [S]
[info]   | +-org.playframework:play_2.13:3.0.0 [S]
stays the same.
org.playframework:play_2.13:3.0.0, represents a certain version of the Play Framework.
The play_2.13 part denotes that this version of the Play Framework has been compiled with Scala 2.13.
The 3.0.0 part stands for the version of the Play Framework itself.
But I guess it will not hurt

## How to test
Successfully deployed to code
