### PR TITLE
Bump logback-classic to 1.4.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,8 @@ lazy val root = (project in file("."))
       filters,
       specs2 % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4" exclude ("com.fasterxml.jackson.core", "jackson-databind"),
+      // Transient dependency of Play. No newer version of Play 3.0.0 with this vulnerability fixed.
+      "ch.qos.logback" % "logback-classic" % "1.4.14",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.16.0"
     ),
     excludeDependencies ++= Seq(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps logback-classic to 1.4.14. Resolving 4 high vulnerabilities.