### PR TITLE
fix(owners): Add owners for `ai` and `data-science` stacks

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -102,6 +102,8 @@ object Owners extends Owners {
     "newsletters.dev" -> SSA(stack = "newsletters"),
     "multimediatech" -> SSA(stack = "multimedia"),
     "targeted.experiences.core" -> SSA(stack = "targeting"),
-    "engineering.managers" -> SSA(stack = "hiring-and-onboarding")
+    "engineering.managers" -> SSA(stack = "hiring-and-onboarding"),
+    "ai.dev" -> SSA(stack = "ai"),
+    "data.scientists" -> SSA(stack = "data-science")
   )
 }


### PR DESCRIPTION
Add the owners of the `ai` and `data-science` stacks so that AMIable can route messages correctly.

If an owner cannot be found, the alert gets sent to DevX as a fallback address, as seen in the image below:

<img width="941" alt="image" src="https://github.com/guardian/prism/assets/836140/c33a1e60-50fa-43c4-942c-509ffee1b696">