### PR TITLE
Add newsroom res as owners of print prod stack

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -46,6 +46,7 @@ object Owners extends Owners {
     "dotcom.platform" -> SSA("frontend-elk"),
     "identitydev" -> SSA(stack = "discussion"),
     "identitydev" -> SSA(stack = "identity"),
+    "newsroom.resilience" -> SSA("print-production"),
     "digitalcms.dev" -> SSA("crosswords"),
     "digitalcms.dev" -> SSA("flexible"),
     "digitalcms.dev" -> SSA("flexible-secondary"),


### PR DESCRIPTION
I've just seen this listing linked in chat this morning, and we're not signed up for notifications from our stack. This PR fixes that