### PR TITLE
ci: Adopt `guardian/actions-riff-raff`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+
+      # These permissions are required by guardian/actions-riff-raff...
+      id-token: write # ...to exchange an OIDC JWT ID token for AWS credentials
+      pull-requests: write #...to comment on PRs
+
     steps:
       - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       # Node is needed for CDK
       - name: Setup node
@@ -33,3 +33,15 @@ jobs:
           java-version: '11' # TODO read this from the `.java-version` file in the repository
           distribution: 'corretto'
       - run: ./scripts/ci
+
+      - uses: guardian/actions-riff-raff@v4
+        with:
+          projectName: devx::prism
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          configPath: riff-raff.yaml # TODO switch to auto-generating this file
+          contentDirectories: |
+            cdk.out:
+              - cdk/cdk.out
+            prism:
+              - target/prism.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           configPath: riff-raff.yaml # TODO switch to auto-generating this file
           contentDirectories: |
-            cdk.out:
+            cloudformation:
               - cdk/cdk.out
             prism:
               - target/prism.deb

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,6 @@ logLevel := Level.Warn
 // The Typesafe repository
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")

--- a/scripts/ci
+++ b/scripts/ci
@@ -2,15 +2,13 @@
 
 set -e
 
-if [[ ! -z "${TEAMCITY_VERSION}" ]]; then
-  echo "Running in TeamCity. Nope!"
-  exit 0
-fi
-
 # build CDK first to ensure it is on disk for SBT to pick up
 (
   cd cdk
   ./script/ci
 )
 
-sbt clean scalafmtSbtCheck scalafmtCheckAll compile test riffRaffUpload
+sbt clean scalafmtSbtCheck scalafmtCheckAll compile test debian:packageBin
+
+# `sbt debian:packageBin` produces `target/prism_1.0-SNAPSHOT_all.deb`. Rename it to something easier.
+mv target/prism_1.0-SNAPSHOT_all.deb target/prism.deb


### PR DESCRIPTION
## What does this change?
The SBT plugin [sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact) is deprecated. This change adopts [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff) in its place.

## How to test
[Deploy to CODE](https://riffraff.gutools.co.uk/deployment/view/11388307-b992-4441-9a89-735f45959931), and observe it succeed. Also observe the build info at the [bottom](https://github.com/guardian/prism/blob/d417371a06924c323683e6157e7582fce9abdaf8/app/views/index.scala.html#L69-L72) of https://prism.code.dev-gutools.co.uk/ matching the deployed build.