### PR TITLE
Drop `play-json-extensions` dependency

### DIFF
--- a/app/jsonimplicits/implicits.scala
+++ b/app/jsonimplicits/implicits.scala
@@ -5,8 +5,6 @@ import java.time.{Instant, ZoneId, ZoneOffset}
 
 import _root_.model.{Owner, SSA}
 import agent._
-import ai.x.play.json.Encoders.encoder
-import ai.x.play.json.Jsonx
 import collectors._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
@@ -73,8 +71,43 @@ object model {
       Json.writes[RecurringCharge]
     Json.writes[Reservation]
   }
-  // this case class contains over 22 fields, which is more than Scala permits, so using the play-json-extensions library instead of the normal Json.writes
-  implicit val rdsWriter: Writes[Rds] = Jsonx.formatCaseClass[Rds]
+  // json-play does not support automatically generating a writer for case clases with 22+ fields.
+  // Manually write one to get around this limitation.
+  implicit val rdsWriter: Writes[Rds] = OWrites[Rds](obj =>
+    JsObject(
+      Seq(
+        "arn" -> Json.toJson(obj.arn),
+        "allocatedStorage" -> Json.toJson(obj.allocatedStorage),
+        "availabilityZone" -> Json.toJson(obj.availabilityZone),
+        "secondaryAvailabilityZone" -> Json.toJson(
+          obj.secondaryAvailabilityZone
+        ),
+        "engineVersion" -> Json.toJson(obj.engineVersion),
+        "instanceCreateTime" -> Json.toJson(obj.instanceCreateTime),
+        "dbInstanceClass" -> Json.toJson(obj.dbInstanceClass),
+        "dbInstanceStatus" -> Json.toJson(obj.dbInstanceStatus),
+        "caCertificateIdentifier" -> Json.toJson(obj.caCertificateIdentifier),
+        "dbiResourceId" -> Json.toJson(obj.dbiResourceId),
+        "dbInstanceIdentifier" -> Json.toJson(obj.dbInstanceIdentifier),
+        "engine" -> Json.toJson(obj.engine),
+        "publiclyAccessible" -> Json.toJson(obj.publiclyAccessible),
+        "iamDatabaseAuthenticationEnabled" -> Json.toJson(
+          obj.iamDatabaseAuthenticationEnabled
+        ),
+        "performanceInsightsEnabled" -> Json.toJson(
+          obj.performanceInsightsEnabled
+        ),
+        "multiAZ" -> Json.toJson(obj.multiAZ),
+        "storageEncrypted" -> Json.toJson(obj.storageEncrypted),
+        "vpcId" -> Json.toJson(obj.vpcId),
+        "dbSubnetGroupName" -> Json.toJson(obj.dbSubnetGroupName),
+        "vpcSecurityGroupId" -> Json.toJson(obj.vpcSecurityGroupId),
+        "storageType" -> Json.toJson(obj.storageType),
+        "autoMinorVersionUpgrade" -> Json.toJson(obj.autoMinorVersionUpgrade),
+        "tags" -> Json.toJson(obj.tags)
+      )
+    )
+  )
 
   implicit val domainResourceRecordWriter: Writes[DomainResourceRecord] =
     Json.writes[DomainResourceRecord]

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,6 @@ lazy val root = (project in file("."))
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersionOne,
       "org.playframework" %% "play-json" % "3.0.2",
       "org.playframework" %% "play-json-joda" % "3.0.2",
-      "ai.x" %% "play-json-extensions" % "0.42.0",
       ws,
       "org.scala-stm" %% "scala-stm" % "0.11.1",
       filters,
@@ -68,10 +67,6 @@ lazy val root = (project in file("."))
       // Transient dependency of Play. No newer version of Play 3.0.2 with this vulnerability fixed.
       "ch.qos.logback" % "logback-classic" % "1.5.5",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.0"
-    ),
-    excludeDependencies ++= Seq(
-      // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
-      ExclusionRule(organization = "com.typesafe.play")
     ),
     scalacOptions ++= List(
       "-encoding",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,6 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
-
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Drops the `play-json-extensions` dependency. This dependency was used to auto-generate JSON Writer implementations for case classes with more than 22 fields.

Unfortunately it appears this dependency hasn't been updated in a long time and [doesn't fully support Play 3 yet](https://github.com/bizzabo/play-json-extensions/issues/94) causing us to have to do some trickery with dependencies to avoid loading in any Play 2 dependencies, specifically Akka.

Thankfully we only had 1 class that was using this extension which was quite easy to write a custom JSON Writer implementation for.