### PR TITLE
Dependency cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,8 +64,6 @@ lazy val root = (project in file("."))
       filters,
       specs2 % "test",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4" exclude ("com.fasterxml.jackson.core", "jackson-databind"),
-      // Transient dependency of Play. No newer version of Play 3.0.2 with this vulnerability fixed.
-      "ch.qos.logback" % "logback-classic" % "1.5.5",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.0"
     ),
     excludeDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.13.13"
 
-val awsVersion = "2.25.13"
+val awsVersion = "2.25.31"
 val awsVersionOne = "1.12.700"
 
 def env(propName: String): String =
@@ -54,7 +54,6 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "iam" % awsVersion,
       "software.amazon.awssdk" % "rds" % awsVersion,
       "software.amazon.awssdk" % "cloudformation" % awsVersion,
-      "com.beust" % "jcommander" % "1.82", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommanderbu
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersionOne,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersionOne,
       "org.playframework" %% "play-json" % "3.0.2",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps AWS SDK dependencies to `2.25.31`, also removes some transient dependency overrides which are no longer required.
