### PR TITLE
chore(lint): Fail on `prettier` errors

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,25 +1,25 @@
 #!/usr/bin/env node
-import "source-map-support/register";
-import { App } from "aws-cdk-lib";
-import { PrismAccess } from "../lib/prism-access";
-import { PrismEc2App } from "../lib/prism-ec2-app";
+import 'source-map-support/register';
+import { App } from 'aws-cdk-lib';
+import { PrismAccess } from '../lib/prism-access';
+import { PrismEc2App } from '../lib/prism-ec2-app';
 
 const app = new App();
 
-new PrismEc2App(app, "Prism-CODE", {
-	stage: "CODE",
-	domainName: "prism.code.dev-gutools.co.uk",
+new PrismEc2App(app, 'Prism-CODE', {
+	stage: 'CODE',
+	domainName: 'prism.code.dev-gutools.co.uk',
 	minimumInstances: 1,
-	cloudFormationStackName: "prism-CODE",
-	env: { region: "eu-west-1" },
+	cloudFormationStackName: 'prism-CODE',
+	env: { region: 'eu-west-1' },
 });
 
-new PrismEc2App(app, "Prism-PROD", {
-	stage: "PROD",
-	domainName: "prism.gutools.co.uk",
+new PrismEc2App(app, 'Prism-PROD', {
+	stage: 'PROD',
+	domainName: 'prism.gutools.co.uk',
 	minimumInstances: 2,
-	cloudFormationStackName: "prism-PROD",
-	env: { region: "eu-west-1" },
+	cloudFormationStackName: 'prism-PROD',
+	env: { region: 'eu-west-1' },
 });
 
-new PrismAccess(app, "PrismAccessStackSet");
+new PrismAccess(app, 'PrismAccessStackSet');

--- a/cdk/lib/prism-access.test.ts
+++ b/cdk/lib/prism-access.test.ts
@@ -1,12 +1,12 @@
-import { App } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
-import { PrismAccess } from "./prism-access";
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PrismAccess } from './prism-access';
 
-describe("The PrismAccess stack", () => {
-  it("matches the snapshot", () => {
-    const app = new App();
-    const stack = new PrismAccess(app, "prism-access");
+describe('The PrismAccess stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+		const stack = new PrismAccess(app, 'prism-access');
 
-    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
-  });
+		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+	});
 });

--- a/cdk/lib/prism-access.ts
+++ b/cdk/lib/prism-access.ts
@@ -1,80 +1,87 @@
-import { GuArnParameter, GuStack } from "@guardian/cdk/lib/constructs/core";
-import { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
-import { GuRole } from "@guardian/cdk/lib/constructs/iam";
-import { CfnOutput } from "aws-cdk-lib";
-import type { App } from "aws-cdk-lib";
-import { ArnPrincipal, Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { GuArnParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
+import { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
+import { GuRole } from '@guardian/cdk/lib/constructs/iam';
+import { CfnOutput } from 'aws-cdk-lib';
+import type { App } from 'aws-cdk-lib';
+import {
+	ArnPrincipal,
+	Effect,
+	Policy,
+	PolicyStatement,
+} from 'aws-cdk-lib/aws-iam';
 
 export class PrismAccess extends GuStack {
-  private static app: AppIdentity = {
-    app: "prism",
-  };
+	private static app: AppIdentity = {
+		app: 'prism',
+	};
 
-  constructor(scope: App, id: string) {
-    super(scope, id, {
-      description: "CloudFormation template to create the prism role.",
-      stack: "deploy",
-      stage: "INFRA", // singleton stack
-    });
+	constructor(scope: App, id: string) {
+		super(scope, id, {
+			description: 'CloudFormation template to create the prism role.',
+			stack: 'deploy',
+			stage: 'INFRA', // singleton stack
+		});
 
-    /*
+		/*
     Looks like some @guardian/cdk constructs are not applying the App tag.
     I suspect since https://github.com/guardian/cdk/pull/326.
     Until that is fixed, we can safely, manually apply it to all constructs in tree from `this` as it's a single app stack.
     TODO: remove this once @guardian/cdk has been fixed.
      */
-    AppIdentity.taggedConstruct(PrismAccess.app, this);
+		AppIdentity.taggedConstruct(PrismAccess.app, this);
 
-    const parameters = {
-      PrismAccount: new GuArnParameter(this, "PrismAccount", {
-        description: "The ARN of the account in which Prism is running - looks like arn:aws:iam::<account-number>:root",
-      }),
-    };
+		const parameters = {
+			PrismAccount: new GuArnParameter(this, 'PrismAccount', {
+				description:
+					'The ARN of the account in which Prism is running - looks like arn:aws:iam::<account-number>:root',
+			}),
+		};
 
-    /*
-     * This is the external prism role in each account which is used by prism to crawl data from that account.
-     */
-    const prismRole = new GuRole(this, "PrismRole", {
-      description: "Role Prism uses to crawl resources in this account",
-      assumedBy: new ArnPrincipal(parameters.PrismAccount.valueAsString),
-    });
+		/*
+		 * This is the external prism role in each account which is used by prism to crawl data from that account.
+		 */
+		const prismRole = new GuRole(this, 'PrismRole', {
+			description: 'Role Prism uses to crawl resources in this account',
+			assumedBy: new ArnPrincipal(parameters.PrismAccount.valueAsString),
+		});
 
-    this.overrideLogicalId(prismRole, {
-      logicalId: "PrismRole",
-      reason: "We override this to ensure that we do not replace the existing resource",
-    });
+		this.overrideLogicalId(prismRole, {
+			logicalId: 'PrismRole',
+			reason:
+				'We override this to ensure that we do not replace the existing resource',
+		});
 
-    new Policy(this, "PrismPolicy", {
-      policyName: "PrismCollection",
-      roles: [prismRole],
-      statements: [
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          resources: ["*"],
-          actions: [
-            "ec2:Describe*",
-            "iam:Get*",
-            "iam:List*",
-            "autoscaling:Describe*",
-            "s3:ListAllMyBuckets",
-            "s3:GetBucketLocation",
-            "acm:ListCertificates",
-            "acm:DescribeCertificate",
-            "route53:List*",
-            "route53:Get*",
-            "elasticloadbalancing:Describe*",
-            "lambda:ListFunctions",
-            "lambda:ListTags",
-            "cloudformation:Describe*",
-            "cloudformation:Get*",
-          ],
-        }),
-      ],
-    });
+		new Policy(this, 'PrismPolicy', {
+			policyName: 'PrismCollection',
+			roles: [prismRole],
+			statements: [
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					resources: ['*'],
+					actions: [
+						'ec2:Describe*',
+						'iam:Get*',
+						'iam:List*',
+						'autoscaling:Describe*',
+						's3:ListAllMyBuckets',
+						's3:GetBucketLocation',
+						'acm:ListCertificates',
+						'acm:DescribeCertificate',
+						'route53:List*',
+						'route53:Get*',
+						'elasticloadbalancing:Describe*',
+						'lambda:ListFunctions',
+						'lambda:ListTags',
+						'cloudformation:Describe*',
+						'cloudformation:Get*',
+					],
+				}),
+			],
+		});
 
-    new CfnOutput(this, "Role", {
-      value: prismRole.roleArn,
-      description: "Prism Role",
-    });
-  }
+		new CfnOutput(this, 'Role', {
+			value: prismRole.roleArn,
+			description: 'Prism Role',
+		});
+	}
 }

--- a/cdk/lib/prism-ec2-app.test.ts
+++ b/cdk/lib/prism-ec2-app.test.ts
@@ -1,15 +1,15 @@
-import { App } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
-import { PrismEc2App } from "./prism-ec2-app";
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PrismEc2App } from './prism-ec2-app';
 
-describe("The PrismEc2App stack", () => {
-  it("matches the snapshot", () => {
-    const app = new App();
-    const stack = new PrismEc2App(app, "prism", {
-      stage: "PROD",
-      domainName: "prism.gutools.co.uk",
-      minimumInstances: 2,
-    });
-    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
-  });
+describe('The PrismEc2App stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+		const stack = new PrismEc2App(app, 'prism', {
+			stage: 'PROD',
+			domainName: 'prism.gutools.co.uk',
+			minimumInstances: 2,
+		});
+		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+	});
 });

--- a/cdk/lib/prism-ec2-app.ts
+++ b/cdk/lib/prism-ec2-app.ts
@@ -1,95 +1,116 @@
-import { GuPlayApp } from "@guardian/cdk";
-import { AccessScope } from "@guardian/cdk/lib/constants";
-import type { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
-import type { GuStackProps } from "@guardian/cdk/lib/constructs/core/stack";
-import { GuStack } from "@guardian/cdk/lib/constructs/core/stack";
+import { GuPlayApp } from '@guardian/cdk';
+import { AccessScope } from '@guardian/cdk/lib/constants';
+import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/stack';
+import { GuStack } from '@guardian/cdk/lib/constructs/core/stack';
 import {
-  GuAllowPolicy,
-  GuAssumeRolePolicy,
-  GuDynamoDBReadPolicy,
-  GuGetS3ObjectsPolicy,
-} from "@guardian/cdk/lib/constructs/iam";
-import type { App } from "aws-cdk-lib";
-import { Duration } from "aws-cdk-lib";
-import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
-import { BlockDeviceVolume, EbsDeviceVolumeType } from "aws-cdk-lib/aws-autoscaling";
-import { InstanceClass, InstanceSize, InstanceType, Peer } from "aws-cdk-lib/aws-ec2";
+	GuAllowPolicy,
+	GuAssumeRolePolicy,
+	GuDynamoDBReadPolicy,
+	GuGetS3ObjectsPolicy,
+} from '@guardian/cdk/lib/constructs/iam';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+import type { CfnAutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
+import {
+	BlockDeviceVolume,
+	EbsDeviceVolumeType,
+} from 'aws-cdk-lib/aws-autoscaling';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	Peer,
+} from 'aws-cdk-lib/aws-ec2';
 
-interface PrismEc2AppProps extends Omit<GuStackProps, "description" | "stack"> {
-  domainName: string;
-  minimumInstances: number;
+interface PrismEc2AppProps extends Omit<GuStackProps, 'description' | 'stack'> {
+	domainName: string;
+	minimumInstances: number;
 }
 
 export class PrismEc2App extends GuStack {
-  private static app: AppIdentity = {
-    app: "prism",
-  };
+	private static app: AppIdentity = {
+		app: 'prism',
+	};
 
-  constructor(scope: App, id: string, props: PrismEc2AppProps) {
-    super(scope, id, { ...props, description: "Prism - service discovery", stack: "deploy" });
+	constructor(scope: App, id: string, props: PrismEc2AppProps) {
+		super(scope, id, {
+			...props,
+			description: 'Prism - service discovery',
+			stack: 'deploy',
+		});
 
-    const pattern = new GuPlayApp(this, {
-      ...PrismEc2App.app,
-      applicationLogging: {
-        enabled: true,
-      },
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      userData: {
-        distributable: {
-          fileName: "prism.deb",
-          executionStatement: `dpkg -i /${PrismEc2App.app.app}/prism.deb`,
-        },
-      },
-      certificateProps: {
-        domainName: props.domainName,
-      },
-      monitoringConfiguration:
-        this.stage === "PROD"
-          ? {
-              snsTopicName: "devx-alerts",
-              http5xxAlarm: false,
-              unhealthyInstancesAlarm: true,
-            }
-          : { noMonitoring: true },
-      access: { scope: AccessScope.INTERNAL, cidrRanges: [Peer.ipv4("10.0.0.0/8")] },
-      roleConfiguration: {
-        additionalPolicies: [
-          new GuAllowPolicy(this, "DescribeEC2BonusPolicy", {
-            resources: ["*"],
-            actions: ["EC2:Describe*"],
-          }),
-          new GuDynamoDBReadPolicy(this, "ConfigPolicy", { tableName: "config-deploy" }),
-          new GuGetS3ObjectsPolicy(this, "DataPolicy", {
-            bucketName: "prism-data",
-          }),
-          new GuAssumeRolePolicy(this, "CrawlerPolicy", {
-            resources: ["arn:aws:iam::*:role/*Prism*", "arn:aws:iam::*:role/*prism*"],
-          }),
-        ],
-      },
-      scaling: {
-        minimumInstances: props.minimumInstances,
-      },
-      blockDevices: [
-        {
-          deviceName: "/dev/sda1",
-          volume: BlockDeviceVolume.ebs(8, {
-            volumeType: EbsDeviceVolumeType.GP2,
-          }),
-        },
-      ],
-    });
+		const pattern = new GuPlayApp(this, {
+			...PrismEc2App.app,
+			applicationLogging: {
+				enabled: true,
+			},
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+			userData: {
+				distributable: {
+					fileName: 'prism.deb',
+					executionStatement: `dpkg -i /${PrismEc2App.app.app}/prism.deb`,
+				},
+			},
+			certificateProps: {
+				domainName: props.domainName,
+			},
+			monitoringConfiguration:
+				this.stage === 'PROD'
+					? {
+							snsTopicName: 'devx-alerts',
+							http5xxAlarm: false,
+							unhealthyInstancesAlarm: true,
+						}
+					: { noMonitoring: true },
+			access: {
+				scope: AccessScope.INTERNAL,
+				cidrRanges: [Peer.ipv4('10.0.0.0/8')],
+			},
+			roleConfiguration: {
+				additionalPolicies: [
+					new GuAllowPolicy(this, 'DescribeEC2BonusPolicy', {
+						resources: ['*'],
+						actions: ['EC2:Describe*'],
+					}),
+					new GuDynamoDBReadPolicy(this, 'ConfigPolicy', {
+						tableName: 'config-deploy',
+					}),
+					new GuGetS3ObjectsPolicy(this, 'DataPolicy', {
+						bucketName: 'prism-data',
+					}),
+					new GuAssumeRolePolicy(this, 'CrawlerPolicy', {
+						resources: [
+							'arn:aws:iam::*:role/*Prism*',
+							'arn:aws:iam::*:role/*prism*',
+						],
+					}),
+				],
+			},
+			scaling: {
+				minimumInstances: props.minimumInstances,
+			},
+			blockDevices: [
+				{
+					deviceName: '/dev/sda1',
+					volume: BlockDeviceVolume.ebs(8, {
+						volumeType: EbsDeviceVolumeType.GP2,
+					}),
+				},
+			],
+		});
 
-    // The pattern does not currently offer support for customising healthchecks via props
-    pattern.targetGroup.configureHealthCheck({
-      path: "/management/healthcheck",
-      unhealthyThresholdCount: 10,
-      interval: Duration.seconds(5),
-      timeout: Duration.seconds(3),
-    });
+		// The pattern does not currently offer support for customising healthchecks via props
+		pattern.targetGroup.configureHealthCheck({
+			path: '/management/healthcheck',
+			unhealthyThresholdCount: 10,
+			interval: Duration.seconds(5),
+			timeout: Duration.seconds(3),
+		});
 
-    // Similarly the pattern does not offer support for extending the default ASG grace period via props
-    const cfnAsg = pattern.autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
-    cfnAsg.healthCheckGracePeriod = 500;
-  }
+		// Similarly the pattern does not offer support for extending the default ASG grace period via props
+		const cfnAsg = pattern.autoScalingGroup.node
+			.defaultChild as CfnAutoScalingGroup;
+		cfnAsg.healthCheckGracePeriod = 500;
+	}
 }

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -18,6 +18,7 @@
         "aws-cdk-lib": "2.157.0",
         "constructs": "10.3.0",
         "eslint": "^8.57.0",
+        "eslint-plugin-prettier": "5.2.1",
         "jest": "^29.7.0",
         "prettier": "^3.3.3",
         "source-map-support": "^0.5.20",
@@ -1443,6 +1444,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3737,6 +3750,36 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+      "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -3920,6 +3963,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -6378,6 +6427,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -7167,6 +7228,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -7385,8 +7462,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -22,6 +22,7 @@
     "aws-cdk-lib": "2.157.0",
     "constructs": "10.3.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-prettier": "5.2.1",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
     "source-map-support": "^0.5.20",
@@ -55,15 +56,13 @@
       "sourceType": "module"
     },
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "prettier"
     ],
     "rules": {
       "@typescript-eslint/no-inferrable-types": 0,
       "import/no-namespace": 2,
-      "quotes": [
-        "error",
-        "double"
-      ]
+      "prettier/prettier": "error"
     },
     "ignorePatterns": [
       "**/*.js",


### PR DESCRIPTION
## What does this change?
Configure `eslint` to fail on `prettier` errors. This ensures a consistent style for quote marks, indent levels, etc. It also means the project uses the departmental code style.

This is a no-op, as demonstrated by the CDK snapshot remaining unchanged.