### PR TITLE
feat: Perform EC2 deployments via CloudFormation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
             cdk.out:
               - cdk/cdk.out
             prism:
-              - target/prism.deb
+              - dist

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -13,6 +13,7 @@ new Prism(app, 'Prism-CODE', {
 	minimumInstances: 1,
 	cloudFormationStackName: 'prism-CODE',
 	env: { region: 'eu-west-1' },
+	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 });
 
 new Prism(app, 'Prism-PROD', {
@@ -21,6 +22,7 @@ new Prism(app, 'Prism-PROD', {
 	minimumInstances: 2,
 	cloudFormationStackName: 'prism-PROD',
 	env: { region: 'eu-west-1' },
+	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 });
 
 new PrismAccess(app, 'PrismAccessStackSet');

--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -12,7 +12,7 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
-      "GuPlayApp",
+      "GuEc2AppExperimental",
       "GuDistributionBucketParameter",
       "GuCertificate",
       "GuInstanceRole",
@@ -77,8 +77,49 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AutoScalingGroupPrismASG36691601": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
+        "Roles": [
+          {
+            "Ref": "InstanceRolePrism96D154B7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupPrismASG36691601": {
+      "CreationPolicy": {
+        "AutoScalingCreationPolicy": {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": {
+          "Count": 2,
+          "Timeout": "PT16M",
+        },
+      },
+      "DependsOn": [
+        "AsgRollingUpdatePolicy2A1DDC6F",
+      ],
+      "Properties": {
+        "DesiredCapacity": "2",
         "HealthCheckGracePeriod": 900,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
@@ -148,6 +189,18 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MaxBatchSize": 4,
+          "MinInstancesInService": 2,
+          "MinSuccessfulInstancesPercent": 100,
+          "PauseTime": "PT16M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
+          "WaitOnResourceSignals": true,
+        },
+      },
     },
     "CertificatePrism0841D21D": {
       "DeletionPolicy": "Retain",
@@ -1181,6 +1234,10 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
                   "Value": "prism",
                 },
                 {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
+                },
+                {
                   "Key": "gu:cdk:version",
                   "Value": "TEST",
                 },
@@ -1208,6 +1265,10 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
                 {
                   "Key": "App",
                   "Value": "prism",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
                 },
                 {
                   "Key": "gu:cdk:version",
@@ -1238,13 +1299,60 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
                 "",
                 [
                   "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupPrismASG36691601           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
 mkdir -p $(dirname '/prism/prism-TEST.deb')
 aws s3 cp 's3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
                   "/deploy/PROD/prism/prism-TEST.deb' '/prism/prism-TEST.deb'
-dpkg -i /prism/prism-TEST.deb",
+dpkg -i /prism/prism-TEST.deb
+# GuEc2AppExperimental UserData Start
+
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupPrismC8B388A7",
+                  },
+                  "         --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupPrismC8B388A7",
+                  },
+                  "           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance running build TEST is healthy in target group."
+      
+# GuEc2AppExperimental UserData End",
                 ],
               ],
             },
@@ -1257,6 +1365,10 @@ dpkg -i /prism/prism-TEST.deb",
               {
                 "Key": "App",
                 "Value": "prism",
+              },
+              {
+                "Key": "gu:build-identifier",
+                "Value": "TEST",
               },
               {
                 "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -1238,13 +1238,13 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
                 "",
                 [
                   "#!/bin/bash
-mkdir -p $(dirname '/prism/prism.deb')
+mkdir -p $(dirname '/prism/prism-TEST.deb')
 aws s3 cp 's3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/deploy/PROD/prism/prism.deb' '/prism/prism.deb'
-dpkg -i /prism/prism.deb",
+                  "/deploy/PROD/prism/prism-TEST.deb' '/prism/prism-TEST.deb'
+dpkg -i /prism/prism-TEST.deb",
                 ],
               ],
             },

--- a/cdk/lib/prism.test.ts
+++ b/cdk/lib/prism.test.ts
@@ -9,6 +9,7 @@ describe('The PrismEc2App stack', () => {
 			stage: 'PROD',
 			domainName: 'prism.gutools.co.uk',
 			minimumInstances: 2,
+			buildIdentifier: 'TEST',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -25,6 +25,12 @@ import {
 interface PrismProps extends Omit<GuStackProps, 'description' | 'stack'> {
 	domainName: string;
 	minimumInstances: number;
+
+	/**
+	 * Which application build to run.
+	 * This will typically match the build number provided by CI.
+	 */
+	buildIdentifier: string;
 }
 
 export class Prism extends GuStack {
@@ -37,6 +43,10 @@ export class Prism extends GuStack {
 			app,
 		});
 
+		const { buildIdentifier } = props;
+
+		const filename = `${app}-${buildIdentifier}.deb`;
+
 		const pattern = new GuPlayApp(this, {
 			app,
 			applicationLogging: {
@@ -46,8 +56,8 @@ export class Prism extends GuStack {
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
 			userData: {
 				distributable: {
-					fileName: `${app}.deb`,
-					executionStatement: `dpkg -i /${app}/${app}.deb`,
+					fileName: filename,
+					executionStatement: `dpkg -i /${app}/${filename}`,
 				},
 			},
 			certificateProps: {

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -1,4 +1,3 @@
-import { GuPlayApp } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/stack';
 import { GuStack } from '@guardian/cdk/lib/constructs/core/stack';
@@ -8,6 +7,7 @@ import {
 	GuDynamoDBReadPolicy,
 	GuGetS3ObjectsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
+import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import type { CfnAutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
@@ -47,7 +47,9 @@ export class Prism extends GuStack {
 
 		const filename = `${app}-${buildIdentifier}.deb`;
 
-		const pattern = new GuPlayApp(this, {
+		const pattern = new GuEc2AppExperimental(this, {
+			buildIdentifier,
+			applicationPort: 9000,
 			app,
 			applicationLogging: {
 				enabled: true,

--- a/scripts/ci
+++ b/scripts/ci
@@ -13,5 +13,5 @@ set -e
 
 sbt clean scalafmtSbtCheck scalafmtCheckAll compile test debian:packageBin
 
-# `sbt debian:packageBin` produces `target/prism_1.0-SNAPSHOT_all.deb`. Rename it to something easier.
-mv target/prism_1.0-SNAPSHOT_all.deb target/prism.deb
+mkdir -p dist
+mv target/prism_1.0-SNAPSHOT_all.deb "dist/prism-$GITHUB_RUN_NUMBER.deb"


### PR DESCRIPTION
## What does this change?
Uses the new `GuEc2AppExperimental` available in [GuCDK v59.5.0](https://github.com/guardian/cdk/releases/tag/v59.5.0) to deploy changes to the autoscaling group entirely via a CloudFormation update.

## How to test
Deploy the branch?! It should succeed. This has been [done on CODE](https://riffraff.gutools.co.uk/deployment/view/2d014f20-ed9b-4164-b986-dc017e90dc34).

## How can we measure success?
More data points to evaluate the effectiveness of `GuEc2AppExperimental`.