### PR TITLE
fix: Increase health check to 15 minutes

### DIFF
--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -79,7 +79,7 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
   "Resources": {
     "AutoScalingGroupPrismASG36691601": {
       "Properties": {
-        "HealthCheckGracePeriod": 500,
+        "HealthCheckGracePeriod": 900,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
           "LaunchTemplateId": {

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -109,6 +109,6 @@ export class Prism extends GuStack {
 		// Similarly the pattern does not offer support for extending the default ASG grace period via props
 		const cfnAsg = pattern.autoScalingGroup.node
 			.defaultChild as CfnAutoScalingGroup;
-		cfnAsg.healthCheckGracePeriod = 500;
+		cfnAsg.healthCheckGracePeriod = Duration.minutes(15).toSeconds();
 	}
 }


### PR DESCRIPTION
## What does this change?
Deployments are currently flaky with the health check failing every so often due to rate limiting from AWS.

This screenshot shows build 1386 failing and succeeding to deploy:
![image](https://github.com/user-attachments/assets/fce0785c-76c5-4cde-b45b-1cac57c1047b)

Increase the health check grace period as a temporary solution to hopefully increase the determinism of deployments.
