### PR TITLE
chore(deps): Update AWS SDKs from 2.32.23 to 2.32.26

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.13.16"
 
-val awsVersion = "2.32.23"
+val awsVersion = "2.32.26"
 val awsVersionOne = "1.12.788"
 
 def env(propName: String): String =


### PR DESCRIPTION
## What does this change?
Updates the AWS SDK to [2.32.26](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.32.26). Included in this version (well [2.32.25](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.32.25)) is an update to netty 4.1.124, which should resolve https://github.com/guardian/prism/security/dependabot/64.
