### PR TITLE
LaunchTemplateCollector supports ASGs with mixed instance policies

### DIFF
--- a/app/collectors/launchTemplates.scala
+++ b/app/collectors/launchTemplates.scala
@@ -72,6 +72,22 @@ case class AWSLaunchTemplateCollector(
               asg.launchTemplate().launchTemplateId(),
               asg.launchTemplate().version()
             )
+          case asg
+              if asg.mixedInstancesPolicy() != null && asg
+                .mixedInstancesPolicy()
+                .launchTemplate() != null =>
+            AsgLaunchTemplate(
+              asg
+                .mixedInstancesPolicy()
+                .launchTemplate()
+                .launchTemplateSpecification()
+                .launchTemplateId(),
+              asg
+                .mixedInstancesPolicy()
+                .launchTemplate()
+                .launchTemplateSpecification()
+                .version()
+            )
         }
       )
 


### PR DESCRIPTION
With @zekehuntergreen

## What does this change?
Updates LaunchTemplateCollector so that it
- uses describeAutoScalingGroupsPaginator to get multiple pages of results
- returns launch templates within mixed instances policies

# Why
Amigo uses `/active-launch-template-versions` to figure out which AMIs can be deleted - AMIs not associated with an instance, launch template, or launch configuration are removed.
The [transcription service](https://github.com/guardian/transcription-service/) uses spot instances and therefore its launch templates didn't appear in the response from `/active-launch-template-versions` before this change, resulting in Amigo removing its AMIs on a few different occasions.

## How to test
- [x] tested in CODE

## How can we measure success?
AMIs for the transcription service's ASGs will not be automatically deleted by Amigo 🎉 