### PR TITLE
Update Owners.scala

### DIFF
--- a/app/data/Owners.scala
+++ b/app/data/Owners.scala
@@ -106,6 +106,7 @@ object Owners extends Owners {
     "targeted.experiences.core" -> SSA(stack = "targeting"),
     "engineering.managers" -> SSA(stack = "hiring-and-onboarding"),
     "ai.dev" -> SSA(stack = "ai"),
-    "data.scientists" -> SSA(stack = "data-science")
+    "data.scientists" -> SSA(stack = "data-science"),
+    "feast.devs" -> SSA(stack = "feast")
   )
 }


### PR DESCRIPTION
## What does this change?
AMIable (somehow) uses this Prism configuration to route its "out of date AMIs" report to teams. If a team is not present, the [fallback](https://github.com/guardian/prism/blob/0d57f516fab19855cde1c92b205012912ed7095c/app/data/Owners.scala#L36) is used. RelOps just received this report for an app in the `feast` stack. This change updates the configuration so the team receive this directly in future.