### PR TITLE
chore(deps-dev): Update GuCDK from 61.3.1 to 61.5.0 (part 1)

### DIFF
--- a/cdk/lib/__snapshots__/prism.test.ts.snap
+++ b/cdk/lib/__snapshots__/prism.test.ts.snap
@@ -24,7 +24,6 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuWazuhAccess",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
@@ -646,27 +645,6 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "InternalIngressSecurityGroupPrismtoprismWazuhSecurityGroupCEA52DC59000F2CB81F1": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "WazuhSecurityGroup",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "InternalIngressSecurityGroupPrism75546EB8",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
     "ListenerPrism140519A6": {
       "Properties": {
         "Certificates": [
@@ -790,27 +768,6 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
             "GuHttpsEgressSecurityGroupPrism4A68FA56",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerPrismSecurityGroupB966F197",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "LoadBalancerPrismSecurityGrouptoprismWazuhSecurityGroupCEA52DC59000B5566477": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "WazuhSecurityGroup",
             "GroupId",
           ],
         },
@@ -1097,17 +1054,8 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
-            "Description": "Wazuh event logging",
-            "FromPort": 1514,
-            "IpProtocol": "tcp",
-            "ToPort": 1514,
-          },
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Wazuh agent registration",
-            "FromPort": 1515,
-            "IpProtocol": "tcp",
-            "ToPort": 1515,
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
           },
         ],
         "Tags": [
@@ -1137,48 +1085,6 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
-    },
-    "WazuhSecurityGroupfromprismInternalIngressSecurityGroupPrism88D0F57890002E31759F": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "WazuhSecurityGroup",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "InternalIngressSecurityGroupPrism75546EB8",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "WazuhSecurityGroupfromprismLoadBalancerPrismSecurityGroupE6A4FDFF90009CACFBEB": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "WazuhSecurityGroup",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerPrismSecurityGroupB966F197",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "deployPRODprismA0128C9B": {
       "DependsOn": [
@@ -1215,12 +1121,6 @@ exports[`The PrismEc2App stack matches the snapshot 1`] = `
             {
               "Fn::GetAtt": [
                 "GuHttpsEgressSecurityGroupPrism4A68FA56",
-                "GroupId",
-              ],
-            },
-            {
-              "Fn::GetAtt": [
-                "WazuhSecurityGroup",
                 "GroupId",
               ],
             },

--- a/cdk/lib/prism.ts
+++ b/cdk/lib/prism.ts
@@ -20,6 +20,7 @@ import {
 	InstanceSize,
 	InstanceType,
 	Peer,
+	SecurityGroup,
 } from 'aws-cdk-lib/aws-ec2';
 
 interface PrismProps extends Omit<GuStackProps, 'description' | 'stack'> {
@@ -122,5 +123,18 @@ export class Prism extends GuStack {
 		const cfnAsg = pattern.autoScalingGroup.node
 			.defaultChild as CfnAutoScalingGroup;
 		cfnAsg.healthCheckGracePeriod = Duration.minutes(15).toSeconds();
+
+		// A temporary security group with a fixed logical ID, replicating the one removed from GuCDK v61.5.0.
+		const tempSecurityGroup = new SecurityGroup(this, 'WazuhSecurityGroup', {
+			vpc: pattern.vpc,
+			// Must keep the same description, else CloudFormation will try to replace the security group
+			// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#cfn-ec2-securitygroup-groupdescription.
+			description: 'Allow outbound traffic from wazuh agent to manager',
+		});
+		this.overrideLogicalId(tempSecurityGroup, {
+			logicalId: 'WazuhSecurityGroup',
+			reason:
+				"Part one of updating to GuCDK 61.5.0+ whilst using Riff-Raff's ASG deployment type",
+		});
 	}
 }

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,14 +8,14 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "61.3.1",
+        "@guardian/cdk": "61.5.0",
         "@guardian/eslint-config": "11.0.0",
         "@guardian/prettier": "8.0.1",
         "@guardian/tsconfig": "^1.0.0",
         "@types/jest": "30.0.0",
         "@types/node": "22.13.8",
-        "aws-cdk": "2.178.1",
-        "aws-cdk-lib": "2.178.1",
+        "aws-cdk": "2.1007.0",
+        "aws-cdk-lib": "2.189.0",
         "constructs": "10.4.2",
         "eslint": "9.37.0",
         "eslint-plugin-prettier": "5.5.4",
@@ -33,12 +33,6 @@
       "integrity": "sha512-M8MbvtGWlqsU5B7TCh95JQL6hYDI2oQUuQSjCnwJtpRxAcAUT7D32Wt/itJuIz7SZJoeER3RabhtZKE3SLhQ1Q==",
       "dev": true
     },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz",
-      "integrity": "sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA==",
-      "dev": true
-    },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
@@ -46,9 +40,9 @@
       "dev": true
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "39.2.20",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
-      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -57,6 +51,9 @@
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -819,15 +816,15 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "61.3.1",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-61.3.1.tgz",
-      "integrity": "sha512-sZchB7BRFwM74g5O/RiG1tfcXcfz8texKwMr03XJtSM9RUa0vBQbK13+j26W+ng7XeA1qu+2q5CJu+eKZdUN2Q==",
+      "version": "61.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-61.5.0.tgz",
+      "integrity": "sha512-aTUFcRLhQymyZ6t1SwHkj923RWLZHBEqTer+aZbHnm5ffRTB8Qa1wv7pQEh19IeBCOxMTBP4iUqtFay5XCpyfA==",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",
         "aws-sdk": "^2.1692.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.108.0",
+        "codemaker": "^1.111.0",
         "git-url-parse": "^16.0.1",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -840,8 +837,8 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.178.1",
-        "aws-cdk-lib": "2.178.1",
+        "aws-cdk": "2.1007.0",
+        "aws-cdk-lib": "2.189.0",
         "constructs": "10.4.2"
       }
     },
@@ -2819,9 +2816,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.178.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.178.1.tgz",
-      "integrity": "sha512-64z9ARFI90jhX6sfjqqJghGxkfh1T4STxY3ccuRY8OxzAK1FY6XLjKBxSyXi9jJFa3v9nN57x7W32u4hZDj6gw==",
+      "version": "2.1007.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1007.0.tgz",
+      "integrity": "sha512-/UOYOTGWUm+pP9qxg03tID5tL6euC+pb+xo0RBue+xhnUWwj/Bbsw6DbqbpOPMrNzTUxmM723/uMEQmM6S26dw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2834,9 +2831,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.178.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.178.1.tgz",
-      "integrity": "sha512-Sl6/posIlvfoD3ILHlABaCVw2C84jbhlQ+mA8J3DEFbN2RvrPkG4dz4HQfC5IiXQJigu39kmj73JPQCnSKl2iA==",
+      "version": "2.189.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.189.0.tgz",
+      "integrity": "sha512-B5Uha7uRntOAyuKfU0eFtxij3ZVTzGAbetw5qaXlURa68wsWpKlU72/OyKugB6JYkhjCZkSTVVBxd1pVTosxEw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2852,20 +2849,19 @@
       ],
       "dev": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.208",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "^11.3.0",
         "ignore": "^5.3.2",
-        "jsonschema": "^1.4.1",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.3",
-        "table": "^6.8.2",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -3130,7 +3126,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,14 +12,14 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "61.3.1",
+    "@guardian/cdk": "61.5.0",
     "@guardian/eslint-config": "11.0.0",
     "@guardian/prettier": "8.0.1",
     "@guardian/tsconfig": "^1.0.0",
     "@types/jest": "30.0.0",
     "@types/node": "22.13.8",
-    "aws-cdk": "2.178.1",
-    "aws-cdk-lib": "2.178.1",
+    "aws-cdk": "2.1007.0",
+    "aws-cdk-lib": "2.189.0",
     "constructs": "10.4.2",
     "eslint": "9.37.0",
     "eslint-plugin-prettier": "5.5.4",


### PR DESCRIPTION
## What does this change?
Updates GuCDK from 61.3.1 to 61.5.0. As described in the [release notes](https://github.com/guardian/cdk/releases/tag/v61.5.0), this version needs to be updated across a few stages.
