### PR TITLE
chore(deps): Remove `com.amazonaws.aws-java-sdk-autoscaling`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,6 @@ lazy val root = (project in file("."))
       "software.amazon.awssdk" % "cloudformation" % awsVersion,
       "com.beust" % "jcommander" % "1.82", // TODO: remove once security vulnerability introduced by aws sdk v2 fixed: https://snyk.io/vuln/maven:com.beust%3Ajcommanderbu
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersionOne,
-      "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersionOne,
       "org.playframework" %% "play-json" % "3.0.5",
       "org.playframework" %% "play-json-joda" % "3.0.5",
       ws,


### PR DESCRIPTION
## What does this change?
The V1 AWS autoscaling SDK library is [not used](https://github.com/guardian/prism/pull/112/files#r542428273). It was added in https://github.com/guardian/prism/pull/28. Since https://github.com/guardian/prism/pull/112 we've been using the V2 SDK.

## How to test
CI passing should suffice here. I have successfully [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/47b98407-f819-4467-8720-c8aabd08a325) too.