### PR TITLE
Bump AWS SDK to 2.42.26 to fix Netty CVEs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.13.18"
 
-val awsVersion = "2.41.34"
+val awsVersion = "2.42.26"
 
 def env(propName: String): String =
   sys.env.get(propName).filter(_.trim.nonEmpty).getOrElse("DEV")


### PR DESCRIPTION
## What does this change?

Bumps aws sdk to latest version to fix GHSA-pwqr-wmgm-9rr8 and GHSA-w9fj-cfpg-grvv.